### PR TITLE
Docker compose v2

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -30,6 +30,8 @@ const loadPlugins = (app, lando) => Promise.resolve(app.plugins.registry)
   // Merge minotaur
   .each(result => _.merge(app, result));
 
+const defaultComposeSeparator = '_';
+
 /**
  * The class to instantiate a new App
  *
@@ -525,4 +527,9 @@ module.exports = class App {
     .then(() => this.events.emit('post-uninstall'))
     .then(() => this.log.info('uninstalled app.'));
   };
+
+  getServiceContainerId(service) {
+    const sep = this._lando && this._lando.config && this._lando.config.composeSeparator || defaultComposeSeparator;
+    return `${this.project}${sep}${service}${sep}1`;
+  }
 };

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -56,6 +56,8 @@ const engineRunner = (config, command) => (argv, lando) => {
   const app = lando.cache.get(path.basename(config.composeCache));
   app.config = config;
   app.events = new AsyncEvents(lando.log);
+  const sep = lando.config.composeSeparator;
+  app.getServiceContainerId = service => `${app.project}${sep}${service}${sep}1`;
   // Load only what we need so we don't pay the appinit penalty
   const utils = require('./../plugins/lando-tooling/lib/utils');
   const buildTask = require('./../plugins/lando-tooling/lib/build');

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -38,6 +38,11 @@ const getMacProp = prop => shell.sh(['defaults', 'read', `${macOSBase}/Contents/
   .then(data => _.trim(data))
   .catch(() => null);
 
+
+const composeV1Separator = '_';
+const composeV2Separator = '-';
+
+
 /*
  * Creates a new Daemon instance.
  */
@@ -225,4 +230,16 @@ module.exports = class LandoDaemon {
         return Promise.resolve(versions);
     }
   };
+
+  getComposeSeparator() {
+    return new Promise(resolve => {
+      const semver = require('semver');
+      this.getVersions().then(versions => {
+        const isComposeV1 = semver.lt(versions.compose, '2.0.0');
+
+        const composeSeparator = isComposeV1 ? composeV1Separator : composeV2Separator;
+        resolve(composeSeparator);
+      });
+    });
+  }
 };

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -111,8 +111,16 @@ const bootstrapEngine = lando => {
     lando.config.instance
   );
   lando.utils = _.merge({}, require('./utils'), require('./config'));
+
+
+  const separatorPromise = new Promise(resolve => {
+    lando.engine.daemon.getComposeSeparator().then(sep => {
+      lando.config.composeSeparator = sep;
+      resolve();
+    });
+  });
   // Auto move and make executable any scripts
-  return lando.Promise.map(lando.config.plugins, plugin => {
+  const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {
     if (fs.existsSync(plugin.scripts)) {
       const confDir = path.join(lando.config.userConfRoot, 'scripts');
       const dest = lando.utils.moveConfig(plugin.scripts, confDir);
@@ -120,6 +128,8 @@ const bootstrapEngine = lando => {
       lando.log.debug('automoved scripts from %s to %s and set to mode 755', plugin.scripts, confDir);
     }
   });
+
+  return Promise.all([pluginPromise, separatorPromise]);
 };
 
 /*

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -114,10 +114,14 @@ const bootstrapEngine = lando => {
 
 
   const separatorPromise = new Promise(resolve => {
-    lando.engine.daemon.getComposeSeparator().then(sep => {
-      lando.config.composeSeparator = sep;
+    if (lando.engine.daemon.getComposeSeparator) {
+      lando.engine.daemon.getComposeSeparator().then(sep => {
+        lando.config.composeSeparator = sep;
+        resolve();
+      });
+    } else {
       resolve();
-    });
+    }
   });
   // Auto move and make executable any scripts
   const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -114,14 +114,10 @@ const bootstrapEngine = lando => {
 
 
   const separatorPromise = new Promise(resolve => {
-    if (lando.engine.daemon.getComposeSeparator) {
-      lando.engine.daemon.getComposeSeparator().then(sep => {
-        lando.config.composeSeparator = sep;
-        resolve();
-      });
-    } else {
+    lando.engine.daemon.getComposeSeparator().then(sep => {
+      lando.config.composeSeparator = sep;
       resolve();
-    }
+    });
   });
   // Auto move and make executable any scripts
   const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -64,7 +64,7 @@ module.exports = (log = new Log()) => {
       .then(response => {
         log.debug('scan response %s received', url, {
           status: response && response.status,
-          headers: response && response.headers
+          headers: response && response.headers,
         });
         return setGood(url);
       })
@@ -72,8 +72,8 @@ module.exports = (log = new Log()) => {
       .catch(error => {
         const extraInformation = {
           code: error.code,
-          message: error.message
-        }
+          message: error.message,
+        };
         if (error.response) {
           extraInformation.status = error.response.status;
           extraInformation.headers = error.response.headers;

--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -71,9 +71,8 @@ module.exports = (app, lando) => {
     const buildServices = _.get(app, 'opts.services', app.services);
     app.log.verbose('refreshing certificates...', buildServices);
     app.events.on('post-start', 9999, () => lando.Promise.each(buildServices, service => {
-      const sep = lando.config.composeSeperator;
       return app.engine.run({
-        id: `${app.project}${sep}${service}${sep}1`,
+        id: app.getServiceContainerId(service),
         cmd: 'mkdir -p /certs && /helpers/refresh-certs.sh > /certs/refresh.log',
         compose: app.compose,
         project: app.project,
@@ -95,9 +94,8 @@ module.exports = (app, lando) => {
     if (!_.isEmpty(app.nonRoot)) {
       app.log.verbose('perm sweeping flagged non-root containers ...', app.nonRoot);
       app.events.on('post-start', 1, () => lando.Promise.each(app.nonRoot, service => {
-        const sep = lando.config.composeSeperator;
         return app.engine.run({
-          id: `${app.project}${sep}${service}${sep}1`,
+          id: app.getServiceContainerId(service),
           cmd: '/helpers/user-perms.sh --silent',
           compose: app.compose,
           project: app.project,
@@ -173,9 +171,8 @@ module.exports = (app, lando) => {
     .map(container => _.find(app.info, {service: container.service}))
     // Map to a retry of the healthcheck command
     .map(info => lando.Promise.retry(() => {
-      const sep = lando.config.composeSeperator;
       return app.engine.run({
-        id: `${app.project}${sep}${info.service}${sep}1`,
+        id: app.getServiceContainerId(info.service),
         cmd: info.healthcheck,
         compose: app.compose,
         project: app.project,

--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -8,6 +8,7 @@ const toObject = require('./../../lib/utils').toObject;
 const utils = require('./lib/utils');
 const warnings = require('./lib/warnings');
 
+
 // Helper to get http ports
 const getHttpPorts = data => _.get(data, 'Config.Labels["io.lando.http-ports"]', '80,443').split(',');
 const getHttpsPorts = data => _.get(data, 'Config.Labels["io.lando.https-ports"]', '443').split(',');
@@ -70,8 +71,9 @@ module.exports = (app, lando) => {
     const buildServices = _.get(app, 'opts.services', app.services);
     app.log.verbose('refreshing certificates...', buildServices);
     app.events.on('post-start', 9999, () => lando.Promise.each(buildServices, service => {
+      const sep = lando.config.composeSeperator;
       return app.engine.run({
-        id: `${app.project}_${service}_1`,
+        id: `${app.project}${sep}${service}${sep}1`,
         cmd: 'mkdir -p /certs && /helpers/refresh-certs.sh > /certs/refresh.log',
         compose: app.compose,
         project: app.project,
@@ -93,8 +95,9 @@ module.exports = (app, lando) => {
     if (!_.isEmpty(app.nonRoot)) {
       app.log.verbose('perm sweeping flagged non-root containers ...', app.nonRoot);
       app.events.on('post-start', 1, () => lando.Promise.each(app.nonRoot, service => {
+        const sep = lando.config.composeSeperator;
         return app.engine.run({
-          id: `${app.project}_${service}_1`,
+          id: `${app.project}${sep}${service}${sep}1`,
           cmd: '/helpers/user-perms.sh --silent',
           compose: app.compose,
           project: app.project,
@@ -170,8 +173,9 @@ module.exports = (app, lando) => {
     .map(container => _.find(app.info, {service: container.service}))
     // Map to a retry of the healthcheck command
     .map(info => lando.Promise.retry(() => {
+      const sep = lando.config.composeSeperator;
       return app.engine.run({
-        id: `${app.project}_${info.service}_1`,
+        id: `${app.project}${sep}${info.service}${sep}1`,
         cmd: info.healthcheck,
         compose: app.compose,
         project: app.project,

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -7,9 +7,6 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
 
-const composeV1Seperator = '_';
-const composeV2Seperator = '-';
-
 // Default env values
 const defaults = {
   config: {
@@ -90,19 +87,6 @@ module.exports = lando => {
       // @NOTE: we need to use pre node 8.x-isms because pld roles with node 7.9 currently
       fs.writeFileSync(caNormalizedCert, fs.readFileSync(caCert));
     }
-  });
-
-
-  lando.events.on('post-bootstrap-engine', 1, () => {
-    return new Promise(resolve => {
-      const semver = require('semver');
-      lando.engine.daemon.getVersions().then(versions => {
-        const isComposeV1 = semver.lt(versions.compose, '2.0.0');
-
-        lando.config.composeSeperator = isComposeV1 ? composeV1Seperator : composeV2Seperator;
-        resolve();
-      });
-    });
   });
 
   // Return some default things

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -99,7 +99,6 @@ module.exports = lando => {
     const isComposeV1 = semver.lt(versions.compose, '2.0.0')
 
     lando.config.composeSeperator = isComposeV1 ? composeV1Seperator : composeV2Seperator;
-    console.log('changing config', lando.config.composeSeperator)
   });
 
   // Return some default things

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -93,12 +93,16 @@ module.exports = lando => {
   });
 
 
-  lando.events.on('post-bootstrap-engine', 1, async () => {
-    const semver = require('semver');
-    const versions = await lando.engine.daemon.getVersions();
-    const isComposeV1 = semver.lt(versions.compose, '2.0.0')
+  lando.events.on('post-bootstrap-engine', 1, () => {
+    return new Promise(resolve => {
+      const semver = require('semver');
+      lando.engine.daemon.getVersions().then(versions => {
+        const isComposeV1 = semver.lt(versions.compose, '2.0.0');
 
-    lando.config.composeSeperator = isComposeV1 ? composeV1Seperator : composeV2Seperator;
+        lando.config.composeSeperator = isComposeV1 ? composeV1Seperator : composeV2Seperator;
+        resolve();
+      });
+    });
   });
 
   // Return some default things

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -23,6 +23,9 @@ const defaults = {
   },
 };
 
+
+const composeV1Seperator = '_';
+const composeV2Seperator = '-';
 /*
  * Helper to get user conf
  */
@@ -87,6 +90,16 @@ module.exports = lando => {
       // @NOTE: we need to use pre node 8.x-isms because pld roles with node 7.9 currently
       fs.writeFileSync(caNormalizedCert, fs.readFileSync(caCert));
     }
+  });
+
+
+  lando.events.on('post-bootstrap-engine', 1, async () => {
+    const semver = require('semver');
+    const versions = await lando.engine.daemon.getVersions();
+    const isComposeV1 = semver.lt(versions.compose, '2.0.0')
+
+    lando.config.composeSeperator = isComposeV1 ? composeV1Seperator : composeV2Seperator;
+    console.log('changing config', lando.config.composeSeperator)
   });
 
   // Return some default things

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -7,6 +7,9 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
 
+const composeV1Seperator = '_';
+const composeV2Seperator = '-';
+
 // Default env values
 const defaults = {
   config: {
@@ -23,9 +26,6 @@ const defaults = {
   },
 };
 
-
-const composeV1Seperator = '_';
-const composeV2Seperator = '-';
 /*
  * Helper to get user conf
  */

--- a/plugins/lando-proxy/index.js
+++ b/plugins/lando-proxy/index.js
@@ -51,7 +51,7 @@ module.exports = lando => {
     config.proxyConfigDir = path.join(config.proxyDir, 'config');
   });
 
-  lando.events.on('post-bootstrap-engine', async () => {
+  lando.events.on('post-bootstrap-engine', () => {
     const sep = lando.config.composeSeperator;
     lando.config.proxyContainer = `${lando.config.proxyName}${sep}proxy${sep}1`;
   });

--- a/plugins/lando-proxy/index.js
+++ b/plugins/lando-proxy/index.js
@@ -38,7 +38,6 @@ module.exports = lando => {
   lando.events.on('post-bootstrap-config', ({config}) => {
     lando.log.verbose('building proxy config...');
     // Set some non dependent things
-    config.proxyContainer = `${lando.config.proxyName}_proxy_1`;
     config.proxyCurrentPorts = {http: config.proxyHttpPort, https: config.proxyHttpsPort};
     config.proxyDir = path.join(lando.config.userConfRoot, 'proxy');
     config.proxyHttpPorts = _.flatten([config.proxyHttpPort, config.proxyHttpFallbacks]);
@@ -52,7 +51,7 @@ module.exports = lando => {
   });
 
   lando.events.on('post-bootstrap-engine', () => {
-    const sep = lando.config.composeSeperator;
+    const sep = lando.config.composeSeparator;
     lando.config.proxyContainer = `${lando.config.proxyName}${sep}proxy${sep}1`;
   });
 

--- a/plugins/lando-proxy/index.js
+++ b/plugins/lando-proxy/index.js
@@ -32,8 +32,6 @@ const defaultConfig = {
   proxyPassThru: true,
 };
 
-const composeV1Seperator = '_';
-const composeV2Seperator = '-';
 
 module.exports = lando => {
   // Add in some computed config eg things after our config has been settled
@@ -54,15 +52,8 @@ module.exports = lando => {
   });
 
   lando.events.on('post-bootstrap-engine', async () => {
-    const semver = require('semver');
-    const versions = await lando.engine.daemon.getVersions();
-    const isComposeV1 = semver.lt(versions.compose, '2.0.0')
-
-    if (!isComposeV1) {
-      const matcher = new RegExp(composeV1Seperator, 'g');
-      lando.config.proxyContainer = lando.config.proxyContainer.replace(matcher, composeV2Seperator);
-    }
-    console.log('proxy', lando.config.proxyContainer)
+    const sep = lando.config.composeSeperator;
+    lando.config.proxyContainer = `${lando.config.proxyName}${sep}proxy${sep}1`;
   });
 
   // Return config defaults to rebase

--- a/plugins/lando-services/lib/utils.js
+++ b/plugins/lando-services/lib/utils.js
@@ -5,8 +5,6 @@ const _ = require('lodash');
 const getUser = require('./../../../lib/utils').getUser;
 const path = require('path');
 
-const defaultComposeSeperator = '_';
-
 /*
  * Helper to get global deps
  * @TODO: this looks pretty testable? should services have libs?
@@ -51,8 +49,7 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
       if (!_.isEmpty(_.get(app, `config.services.${service}.${section}`, []))) {
         // Run each command
         _.forEach(app.config.services[service][section], cmd => {
-          const sep = app._lando && app._lando.config.composeSeperator || defaultComposeSeperator;
-          const container = `${app.project}${sep}${service}${sep}1`;
+          const container = app.getServiceContainerId(service);
           build.push({
             id: container,
             cmd: ['/bin/sh', '-c', _.isArray(cmd) ? cmd.join(' ') : cmd],

--- a/plugins/lando-services/lib/utils.js
+++ b/plugins/lando-services/lib/utils.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const getUser = require('./../../../lib/utils').getUser;
 const path = require('path');
 
+const defaultComposeSeperator = '_';
+
 /*
  * Helper to get global deps
  * @TODO: this looks pretty testable? should services have libs?
@@ -49,7 +51,7 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
       if (!_.isEmpty(_.get(app, `config.services.${service}.${section}`, []))) {
         // Run each command
         _.forEach(app.config.services[service][section], cmd => {
-          const sep = app._lando && app._lando.config.composeSeperator || '';
+          const sep = app._lando && app._lando.config.composeSeperator || defaultComposeSeperator;
           const container = `${app.project}${sep}${service}${sep}1`;
           build.push({
             id: container,

--- a/plugins/lando-services/lib/utils.js
+++ b/plugins/lando-services/lib/utils.js
@@ -49,7 +49,8 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
       if (!_.isEmpty(_.get(app, `config.services.${service}.${section}`, []))) {
         // Run each command
         _.forEach(app.config.services[service][section], cmd => {
-          const container = `${app.project}_${service}_1`;
+          const sep = app._lando.config.composeSeperator;
+          const container = `${app.project}${sep}${service}${sep}1`;
           build.push({
             id: container,
             cmd: ['/bin/sh', '-c', _.isArray(cmd) ? cmd.join(' ') : cmd],

--- a/plugins/lando-services/lib/utils.js
+++ b/plugins/lando-services/lib/utils.js
@@ -49,7 +49,7 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
       if (!_.isEmpty(_.get(app, `config.services.${service}.${section}`, []))) {
         // Run each command
         _.forEach(app.config.services[service][section], cmd => {
-          const sep = app._lando.config.composeSeperator;
+          const sep = app._lando && app._lando.config.composeSeperator || '';
           const container = `${app.project}${sep}${service}${sep}1`;
           build.push({
             id: container,

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -109,23 +109,21 @@ const parseCommand = (cmd, service) => ({
 /*
  * Helper to build commands
  */
-exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => {
-  return {
-    id: app.getServiceContainerId(service),
-    compose: app.compose,
-    project: app.project,
-    cmd: command,
-    opts: {
-      environment: getCliEnvironment(env),
-      mode: 'attach',
-      workdir: dir || getContainerPath(app.root),
-      user: (user === null) ? getUser(service, app.info) : user,
-      services: _.compact([service]),
-      hijack: false,
-      autoRemove: true,
-    },
-  };
-};
+exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => ({
+  id: app.getServiceContainerId(service),
+  compose: app.compose,
+  project: app.project,
+  cmd: command,
+  opts: {
+    environment: getCliEnvironment(env),
+    mode: 'attach',
+    workdir: dir || getContainerPath(app.root),
+    user: (user === null) ? getUser(service, app.info) : user,
+    services: _.compact([service]),
+    hijack: false,
+    autoRemove: true,
+  },
+});
 
 /*
  * Helper to build docker exec command

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -7,8 +7,6 @@ const getUser = require('./../../../lib/utils').getUser;
 const getCliEnvironment = require('./../../../lib/utils').getCliEnvironment;
 const path = require('path');
 
-const defaultComposeSeperator = '_';
-
 /*
  * Helper to map the cwd on the host to the one in the container
  */
@@ -112,9 +110,8 @@ const parseCommand = (cmd, service) => ({
  * Helper to build commands
  */
 exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => {
-  const sep = app._lando && app._lando.config.composeSeperator || defaultComposeSeperator;
   return {
-    id: `${app.project}${sep}${service}${sep}1`,
+    id: app.getServiceContainerId(service),
     compose: app.compose,
     project: app.project,
     cmd: command,

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -7,6 +7,8 @@ const getUser = require('./../../../lib/utils').getUser;
 const getCliEnvironment = require('./../../../lib/utils').getCliEnvironment;
 const path = require('path');
 
+const defaultComposeSeperator = '_';
+
 /*
  * Helper to map the cwd on the host to the one in the container
  */
@@ -110,7 +112,7 @@ const parseCommand = (cmd, service) => ({
  * Helper to build commands
  */
 exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => {
-  const sep = app._lando && app._lando.config.composeSeperator;
+  const sep = app._lando && app._lando.config.composeSeperator || defaultComposeSeperator;
   return {
     id: `${app.project}${sep}${service}${sep}1`,
     compose: app.compose,

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -110,7 +110,7 @@ const parseCommand = (cmd, service) => ({
  * Helper to build commands
  */
 exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => {
-  const sep = app._lando.config.composeSeperator;
+  const sep = app._lando && app._lando.config.composeSeperator;
   return {
     id: `${app.project}${sep}${service}${sep}1`,
     compose: app.compose,

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -109,21 +109,24 @@ const parseCommand = (cmd, service) => ({
 /*
  * Helper to build commands
  */
-exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => ({
-  id: `${app.project}_${service}_1`,
-  compose: app.compose,
-  project: app.project,
-  cmd: command,
-  opts: {
-    environment: getCliEnvironment(env),
-    mode: 'attach',
-    workdir: dir || getContainerPath(app.root),
-    user: (user === null) ? getUser(service, app.info) : user,
-    services: _.compact([service]),
-    hijack: false,
-    autoRemove: true,
-  },
-});
+exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => {
+  const sep = app._lando.config.composeSeperator;
+  return {
+    id: `${app.project}${sep}${service}${sep}1`,
+    compose: app.compose,
+    project: app.project,
+    cmd: command,
+    opts: {
+      environment: getCliEnvironment(env),
+      mode: 'attach',
+      workdir: dir || getContainerPath(app.root),
+      user: (user === null) ? getUser(service, app.info) : user,
+      services: _.compact([service]),
+      hijack: false,
+      autoRemove: true,
+    },
+  };
+};
 
 /*
  * Helper to build docker exec command


### PR DESCRIPTION
Docker compose v2 switched from using `_` to `-` as a seperator in container ids. 

In lando there are several places where `_` was hardcoded which made it incompatible with docker-compose v2. 

This change seems to address most of those. I am yet to fully test this within our dev-env but that will be easier with this merged.