### PR TITLE
[dev-env] use our traefik that includes openssl

### DIFF
--- a/plugins/lando-proxy/services/proxy/builder.js
+++ b/plugins/lando-proxy/services/proxy/builder.js
@@ -10,7 +10,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
   return {
     services: {
       proxy: {
-        image: 'traefik:2.2.0',
+        image: 'ghcr.io/automattic/vip-container-images/traefik_openssl:v2.7.0',
         command: proxyCommand.join(' '),
         environment: {
           LANDO_APP_PROJECT: '_lando_',


### PR DESCRIPTION
If the user needs a network Proxy for any communication to the outside world the official traefik image will fail to start as it is unable to install openssl during Lando's cert install step

This change switches to our traefik image, which is base traefik with openssl preinstalled.