### PR TITLE
Fallback to compose v1

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -235,7 +235,7 @@ module.exports = class LandoDaemon {
     return new Promise(resolve => {
       const semver = require('semver');
       this.getVersions().then(versions => {
-        const isComposeV1 = semver.lt(versions.compose, '2.0.0');
+        const isComposeV1 = semver.lt(versions.compose || '1.0.0', '2.0.0');
 
         const composeSeparator = isComposeV1 ? composeV1Separator : composeV2Separator;
         resolve(composeSeparator);


### PR DESCRIPTION
On `darwin 21.5.0` getVersions fails to find docker-compose version.

I opened an issue on upstream - https://github.com/lando/cli/issues/153

For now we just fallback to v1