### PR TITLE
Add ability to circumvent pull command on each rebuild

### DIFF
--- a/lib/compose.js
+++ b/lib/compose.js
@@ -97,6 +97,12 @@ exports.pull = (compose, project, opts = {}) => {
   const pull = _(opts.pullable).filter(service => {
     return _.isEmpty(opts.services) || _.includes(opts.services, service);
   }).value();
+
+  // VIP HACK: allow to skip image pull on rebuild if { opts: pull is false }
+  if (opts?.pull === false) {
+    return buildShell('ps', project, compose, {});
+  }
+
   if (!_.isEmpty(pull)) return buildShell('pull', project, compose, {services: pull});
   else return buildShell('ps', project, compose, {});
 };


### PR DESCRIPTION
The way we use the the CLI has us rebuilding containers all the time, each time it tries to pull the images and fails if you're having connectivity issues, regardless of the fact whether you have those images locally already.

This PR introduces an ability to skip the pull if image is present when passing { pull: true } - this is already mentioned in Lando's inline docs but I guess some level of abstraction fails :)

With this PR it's possible to do this:

```javascript

app.events.on( 'pre-rebuild', 1, () => {
  app.opts = { ...( app.opts ), pull: false, nocache: false };
} );
```

Admittedly, this feels a bit hacky, open for other ideas :) 
