### PR TITLE
feat: Update ghcr.io/automattic/vip-container-images/traefik_openssl to latest

### DIFF
--- a/plugins/lando-proxy/services/proxy/builder.js
+++ b/plugins/lando-proxy/services/proxy/builder.js
@@ -10,7 +10,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
   return {
     services: {
       proxy: {
-        image: 'ghcr.io/automattic/vip-container-images/traefik_openssl:2.8',
+        image: 'ghcr.io/automattic/vip-container-images/traefik_openssl:latest',
         command: proxyCommand.join(' '),
         environment: {
           LANDO_APP_PROJECT: '_lando_',


### PR DESCRIPTION
~Ref: https://github.com/Automattic/vip-container-images/pull/368~

Now that we update traefik more often, it is not convenient to update Lando every time there is a new release of traefik. With this PR, we will be using the latest version.
