### PR TITLE
fix: Do not touch .ssh if config.home is empty

### DIFF
--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -115,6 +115,9 @@ module.exports = (app, lando) => {
 
   // Assess our key situation so we can warn users who may have too many
   app.events.on('post-init', () => {
+    if (!lando.config.home) {
+      return;
+    }
     // Get keys on host
     const sshDir = path.resolve(lando.config.home, '.ssh');
     const keys = _(fs.readdirSync(sshDir))

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -63,7 +63,10 @@ module.exports = lando => {
   const caProject = `landocasetupkenobi38ahsoka${lando.config.instance}`;
   const sshDir = path.join(lando.config.home, '.ssh');
   // Ensure some dirs exist before we start
-  _.forEach([caDir, sshDir], dir => mkdirp.sync(dir));
+  mkdirp.sync(caDir);
+  if (lando.config.home) {
+    mkdirp.sync(sshDir);
+  }
 
   // Make sure we have a host-exposed root ca if we don't already
   // NOTE: we don't run this on the caProject otherwise infinite loop happens!


### PR DESCRIPTION
When `lando.config.home` is empty, Lando nevertheless tries to create (and later scan) the `.ssh` directory. When `home` is empty, `.ssh` is created in the current directory.

This PR suppresses all access to `.ssh` if `lando.config.home` is empty.
