### PR TITLE
Fix loading of empty Lando config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -216,7 +216,7 @@ exports.loadFiles = files => _(files)
   .filter(source => fs.existsSync(source) || fs.existsSync(source.file))
   // If the file is just a string lets map it to an object
   .map(source => {
-    return _.isString(source) ? {file: source, data: yaml.safeLoad(fs.readFileSync(source))} : source;
+    return _.isString(source) ? {file: source, data: yaml.safeLoad(fs.readFileSync(source)) || {}} : source;
   })
   // Add on the root directory for mapping purposes
   .map(source => _.merge({}, source, {root: path.dirname(source.file)}))


### PR DESCRIPTION
```
Error: Cannot read properties of null (reading 'pluginDirs')
  @automattic/vip:bin:dev-environment TypeError: Cannot read properties of null (reading 'pluginDirs')
  @automattic/vip:bin:dev-environment     at /.../vip/node_modules/lando/lib/config.js:227:32
```