### PR TITLE
chore(deps): Update uuid to 9.0.0

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -240,7 +240,7 @@ exports.getTasks = (config = {}, argv = {}, tasks = []) => {
  * Helper to setup cache
  */
 exports.setupCache = (log, config) => {
-  const random = require('uuid/v4');
+  const {v4: random} = require('uuid');
   const Cache = require('./cache');
   const cache = new Cache({log, cacheDir: path.join(config.userConfRoot, 'cache')});
   if (!cache.get('id')) cache.set('id', random(), {persist: true});

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "sudo-block": "^2.0.0",
     "through": "^2.3.8",
     "transliteration": "^2.2.0",
-    "uuid": "^3.2.1",
+    "uuid": "^9.0.0",
     "valid-url": "^1.0.9",
     "winston": "2.4.5",
     "yargonaut": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,10 +6199,15 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
This fixes the following deprecation:

> npm WARN deprecated uuid@3.0.1: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.