### PR TITLE
refactor: Rewrite version detection logic

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -316,13 +316,6 @@ module.exports = class Cli {
               console.error(this.makeArt('noDockerDep', 'docker-compose'));
               throw Error('docker-compose could not be located!');
             }
-            // Collect DOCKER VERSION COMPAT info, this can be an async check
-            lando.engine.getCompatibility().then(results => {
-              lando.log.verbose('checking docker version compatibility...');
-              lando.log.debug('compatibility results', _.keyBy(results, 'name'));
-              lando.cache.set('versions', _.assign(lando.versions, _.keyBy(results, 'name')), {persist: true});
-              lando.versions = lando.cache.get('versions');
-            });
             // Show a message saying we are starting docker if its not up, we can also do this async
             // because the auto-start mechanism is downstream, this is just to surface a message
             lando.engine.daemon.isUp().then(isUp => {

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -5,9 +5,7 @@ const _ = require('lodash');
 const Cache = require('./cache');
 const env = require('./env');
 const Events = require('./events');
-const fs = require('fs');
 const Log = require('./logger');
-const path = require('path');
 const Promise = require('./promise');
 const Shell = require('./shell');
 const shell = new Shell();
@@ -31,17 +29,8 @@ const buildDockerCmd = cmd => {
   }
 };
 
-/*
- * Helper to build mac docker version get command
- */
-const getMacProp = prop => shell.sh(['defaults', 'read', `${macOSBase}/Contents/Info.plist`, prop])
-  .then(data => _.trim(data))
-  .catch(() => null);
-
-
 const composeV1Separator = '_';
 const composeV2Separator = '-';
-
 
 /*
  * Creates a new Daemon instance.
@@ -180,55 +169,14 @@ module.exports = class LandoDaemon {
    * Helper to get the versions of the things we need
    */
   getVersions() {
-    switch (process.platform) {
-      case 'darwin':
-        return Promise.all([
-          getMacProp('EngineVersion'),
-          getMacProp('ComposeVersion'),
-          getMacProp('CFBundleShortVersionString'),
-        ])
-        .then(data => ({
-          compose: data[1],
-          engine: data[0],
-          desktop: data[2],
-        }));
-      case 'linux':
-        return Promise.all([
-          shell.sh([`"${this.docker}"`, 'version', '--format', '{{.Server.Version}}']).catch(() => '18.0.0'),
-          shell.sh([`"${this.compose}"`, 'version', '--short']).catch(() => '11.0.0'),
-        ])
-        .then(data => ({
-          compose: _.trim(data[1]),
-          engine: _.trim(data[0]),
-          desktop: false,
-        }));
-      case 'win32':
-        const versions = {
-          compose: '1.24.1',
-          engine: '19.03.1',
-          desktop: '2.1.0.1',
-        };
-
-        // Possible locations of the component config
-        const componentsVersionFiles = [
-          path.resolve(this.compose, '..', '..', 'componentsVersion.json'),
-          path.resolve(this.compose, '..', '..', '..', 'componentsVersion.json'),
-        ];
-
-        // Use the first one we find
-        const componentsVersionFile = _.find(componentsVersionFiles, fs.existsSync);
-        // If we found one, use it but allow for a fallback in case these keys change
-        if (componentsVersionFile) {
-          const componentsVersion = require(componentsVersionFile);
-          versions.compose = _.get(componentsVersion, 'ComposeVersion', versions.compose);
-          versions.engine = _.get(componentsVersion, 'EngineVersion', versions.engine);
-          // There are two different keys that map to the docker desktip version depending
-          // on the version
-          versions.desktop = _.get(componentsVersion, 'Informational', versions.desktop);
-          versions.desktop = _.get(componentsVersion, 'Version', versions.desktop);
-        }
-        return Promise.resolve(versions);
-    }
+    return Promise.all([
+      shell.sh([`"${this.docker}"`, 'version', '--format', '{{.Server.Version}}']).catch(() => '18.0.0'),
+      shell.sh([`"${this.compose}"`, 'version', '--short']).catch(() => '11.0.0'),
+    ])
+    .then(data => ({
+      compose: _.trim(data[1]),
+      engine: _.trim(data[0]),
+    }));
   };
 
   getComposeSeparator() {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -1,7 +1,6 @@
 'use strict';
 
 // Modules
-const _ = require('lodash');
 const LandoDaemon = require('./daemon');
 const Landerode = require('./docker');
 const router = require('./router');
@@ -160,52 +159,6 @@ module.exports = class Engine {
    */
   exists(data) {
     return this.engineCmd('exists', data);
-  };
-
-  /*
-   * @TODO: Need to docblock this correctly so it shows up in the API docs
-   */
-  getCompatibility(supportedVersions = this.supportedVersions) {
-    const semver = require('semver');
-    return this.daemon.getVersions().then(versions => {
-      // Remove the things we don't need depending on platform
-      // @TODO: Should daemon.getVersions just do this automatically?
-      if (process.platform === 'linux') delete versions.desktop;
-      else {
-        delete versions.compose;
-        delete versions.engine;
-      }
-
-      // We do special things with the destop version because it has a four part version string
-      // We basically append part 4 on part 3 and THINK this should approximate semver close enough
-      const clean = version => {
-        const parts = version.split('.');
-        if (_.size(parts) === 4) {
-          parts[2] = `${parts[2]}${parts.pop()}`;
-          version = parts.join('.');
-        }
-        return semver.valid(semver.coerce(version, true));
-      };
-
-      // Docker doesn't use strict semver for the engine and compose strings so we coerce a bit
-      return _(versions)
-        // Do a first map pass to parse
-        .map((version, thing) => ({
-          name: thing,
-          link: supportedVersions[thing].link[process.platform],
-          wants: `${supportedVersions[thing].min} - ${supportedVersions[thing].max}`,
-          version,
-          semversion: clean(version),
-          semmin: clean(supportedVersions[thing].min),
-          semmax: clean(supportedVersions[thing].max),
-        }))
-        // And a second to compare
-        .map(thing => _.merge({}, thing, {
-          dockerVersion: true,
-          satisfied: semver.satisfies(thing.semversion, `${thing.semmin} - ${thing.semmax}`, true),
-        }))
-        .value();
-    });
   };
 
   /**

--- a/lib/env.js
+++ b/lib/env.js
@@ -36,20 +36,29 @@ const getDockerBin = (bin, base) => {
 exports.getDockerBinPath = () => {
   switch (process.platform) {
     case 'darwin':
-      return '/Applications/Docker.app/Contents/Resources/bin';
     case 'linux':
-      return '/usr/share/lando/bin';
+      return '/usr/bin';
     case 'win32':
       const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
       const programData = process.env.ProgramData;
-      // Check for Docker in 2.3.0.5+ first
-      if (fs.existsSync(path.win32.join(programData + '\\DockerDesktop\\version-bin\\docker.exe'))) {
-        return path.win32.join(programData + '\\DockerDesktop\\version-bin');
-      // Otherwise use the legacy path
-      } else {
-         return path.win32.join(programFiles + '\\Docker\\Docker\\resources\\bin');
+      const possiblePaths = [
+        programData + '\\DockerDesktop\\version-bin',
+        programFiles + '\\Docker\\Docker\\resources\\bin',
+        process.env.SystemRoot + '\\System32',
+      ];
+
+      if (process.env.ChocolateyInstall) {
+        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
+      }
+
+      for (const dir of possiblePaths) {
+        if (fs.existsSync(path.win32.join(dir, 'docker.exe'))) {
+          return dir;
+        }
       }
   }
+
+  return false;
 };
 
 /*
@@ -58,12 +67,24 @@ exports.getDockerBinPath = () => {
 exports.getDockerComposeBinPath = () => {
   switch (process.platform) {
     case 'darwin':
-      return '/Applications/Docker.app/Contents/Resources/bin/docker-compose-v1';
     case 'linux':
       return exports.getDockerBinPath();
     case 'win32':
       const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
-      return path.win32.join(programFiles + '\\Docker\\Docker\\resources\\bin');
+      const possiblePaths = [
+        programFiles + '\\Docker\\Docker\\resources\\bin',
+        process.env.SystemRoot + '\\System32',
+      ];
+
+      if (process.env.ChocolateyInstall) {
+        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
+      }
+
+      for (const dir of possiblePaths) {
+        if (fs.existsSync(path.win32.join(dir, 'docker-compose.exe'))) {
+          return dir;
+        }
+      }
   }
 };
 
@@ -73,12 +94,9 @@ exports.getDockerComposeBinPath = () => {
 exports.getComposeExecutable = () => {
   switch (process.platform) {
     case 'darwin':
-      return getDockerBin('docker-compose', exports.getDockerComposeBinPath());
     case 'linux':
-      return getDockerBin('docker-compose', exports.getDockerComposeBinPath());
     case 'win32':
-      return (getDockerBin('docker-compose-v1', exports.getDockerComposeBinPath()) ||
-        getDockerBin('docker-compose', exports.getDockerComposeBinPath()));
+      return getDockerBin('docker-compose', exports.getDockerComposeBinPath());
   }
 };
 
@@ -86,7 +104,7 @@ exports.getComposeExecutable = () => {
  * This should only be needed for linux
  */
 exports.getDockerExecutable = () => {
-  const base = (process.platform === 'linux') ? '/usr/bin' : exports.getDockerBinPath();
+  const base = exports.getDockerBinPath();
   return getDockerBin('docker', base);
 };
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,111 +1,108 @@
 'use strict';
 
 // Modules
-const _ = require('lodash');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const shell = require('shelljs');
 
-/*
- * Helper to get an executable
- */
-const getDockerBin = (bin, base) => {
-  // Do platform appropriate things to get started
+const findFileInPath = (file, paths) => {
   const join = (process.platform === 'win32') ? path.win32.join : path.posix.join;
-  let binPath = (process.platform === 'win32') ? join(base, `${bin}.exe`) : join(base, bin);
-
-  // Use PATH compose executable on posix if ours does not exist
-  if (!fs.existsSync(binPath) || fs.statSync(binPath).isDirectory()) {
-    binPath = _.toString(shell.which(bin));
+  const normalize = (process.platform === 'win32') ? path.win32.normalize : path.posix.normalize;
+  for (const dir of paths) {
+    const fullname = join(dir, file);
+    try {
+      const stat = fs.statSync(fullname, {throwIfNoEntry: false});
+      if (stat && stat.isFile()) {
+        return normalize(fullname);
+      }
+    } catch (err) {
+      // Ignore - mockfs does not respect throwIfNoEntry
+    }
   }
 
-  // If the binpath still does not exist then we should set to false and handle downstream
-  if (!fs.existsSync(binPath)) return false;
-  // Otherwise return a normalized binpath
-  switch (process.platform) {
-    case 'darwin': return path.posix.normalize(binPath);
-    case 'linux': return path.posix.normalize(binPath);
-    case 'win32': return path.win32.normalize(binPath);
-  }
+  const possiblePath = shell.which(file);
+  return (possiblePath !== null) ? normalize(possiblePath.toString()) : false;
 };
 
 /*
  * Helper to get location of docker bin directory
  */
 exports.getDockerBinPath = () => {
-  switch (process.platform) {
-    case 'darwin':
-    case 'linux':
-      return '/usr/bin';
-    case 'win32':
-      const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
-      const programData = process.env.ProgramData;
-      const possiblePaths = [
-        programData + '\\DockerDesktop\\version-bin',
-        programFiles + '\\Docker\\Docker\\resources\\bin',
-        process.env.SystemRoot + '\\System32',
-      ];
-
-      if (process.env.ChocolateyInstall) {
-        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
-      }
-
-      for (const dir of possiblePaths) {
-        if (fs.existsSync(path.win32.join(dir, 'docker.exe'))) {
-          return dir;
-        }
-      }
-  }
-
-  return false;
+  const dirname = (process.platform === 'win32') ? path.win32.dirname : path.posix.dirname;
+  const fullPath = exports.getDockerExecutable();
+  return fullPath ? dirname(fullPath) : false;
 };
 
 /*
  * Helper to get location of docker bin directory
  */
 exports.getDockerComposeBinPath = () => {
-  switch (process.platform) {
-    case 'darwin':
-    case 'linux':
-      return exports.getDockerBinPath();
-    case 'win32':
-      const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
-      const possiblePaths = [
-        programFiles + '\\Docker\\Docker\\resources\\bin',
-        process.env.SystemRoot + '\\System32',
-      ];
-
-      if (process.env.ChocolateyInstall) {
-        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
-      }
-
-      for (const dir of possiblePaths) {
-        if (fs.existsSync(path.win32.join(dir, 'docker-compose.exe'))) {
-          return dir;
-        }
-      }
-  }
+  const dirname = (process.platform === 'win32') ? path.win32.dirname : path.posix.dirname;
+  const fullPath = exports.getComposeExecutable();
+  return fullPath ? dirname(fullPath) : false;
 };
 
 /*
  * Get docker compose binary path
  */
 exports.getComposeExecutable = () => {
+  const possiblePaths = [];
+  let binary;
   switch (process.platform) {
     case 'darwin':
+      possiblePaths.push('/Applications/Docker.app/Contents/Resources/bin');
+      // fallthrough
     case 'linux':
+      binary = 'docker-compose';
+      possiblePaths.push('/usr/local/bin', '/usr/bin');
+      break;
     case 'win32':
-      return getDockerBin('docker-compose', exports.getDockerComposeBinPath());
+      binary = 'docker-compose.exe';
+      const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
+      possiblePaths.push(
+        programFiles + '\\Docker\\Docker\\resources\\bin',
+        process.env.SystemRoot + '\\System32'
+      );
+
+      if (process.env.ChocolateyInstall) {
+        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
+      }
   }
+
+  return findFileInPath(binary, possiblePaths);
 };
 
-/*
- * This should only be needed for linux
- */
 exports.getDockerExecutable = () => {
-  const base = exports.getDockerBinPath();
-  return getDockerBin('docker', base);
+  const possiblePaths = [];
+  let binary;
+  switch (process.platform) {
+    case 'darwin':
+      possiblePaths.push('/Applications/Docker.app/Contents/Resources/bin');
+      // fallthrough
+    case 'linux':
+      binary = 'docker';
+      possiblePaths.push('/usr/local/bin', '/usr/bin');
+      break;
+    case 'win32':
+      binary = 'docker.exe';
+      const programFiles = process.env.ProgramW6432 || process.env.ProgramFiles;
+      const programData = process.env.ProgramData;
+      if (programData) {
+        possiblePaths.push(programData + '\\DockerDesktop\\version-bin');
+      }
+
+      possiblePaths.push(
+        programFiles + '\\Docker\\Docker\\resources\\bin',
+        process.env.SystemRoot + '\\System32'
+      );
+
+      if (process.env.ChocolateyInstall) {
+        possiblePaths.push(process.env.ChocolateyInstall + '\\bin');
+      }
+  }
+
+  return findFileInPath(binary, possiblePaths);
 };
 
 /*

--- a/test/env.spec.js
+++ b/test/env.spec.js
@@ -30,6 +30,7 @@ describe('env', () => {
   describe('#getDockerBinPath', () => {
     it('should return the correct lando-provided path on win32', () => {
       setPlatform('win32');
+      filesystem({'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe': 'CODEZ'});
       process.env.ProgramW6432 = 'C:\\Program Files';
       const dockerBinPath = env.getDockerBinPath();
       const pf = process.env.ProgramW6432;
@@ -41,6 +42,7 @@ describe('env', () => {
 
     it('should fallback to the ProgramFiles path on win32', () => {
       setPlatform('win32');
+      filesystem({'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe': 'CODEZ'});
       const holder = process.env.ProgramW6432;
       process.env.ProgramFiles = 'C:\\Program Files';
       delete process.env.ProgramW6432;
@@ -56,14 +58,14 @@ describe('env', () => {
     it('should return the correct lando-provided path on linux', () => {
       setPlatform('linux');
       const dockerBinPath = env.getDockerBinPath();
-      expect(dockerBinPath).to.equal('/usr/share/lando/bin');
+      expect(dockerBinPath).to.equal('/usr/bin');
       resetPlatform();
     });
 
     it('should return the correct lando-provided path on darwin', () => {
       setPlatform('darwin');
       const dockerBinPath = env.getDockerBinPath();
-      expect(dockerBinPath).to.equal('/Applications/Docker.app/Contents/Resources/bin');
+      expect(dockerBinPath).to.equal('/usr/bin');
       resetPlatform();
     });
   });
@@ -71,10 +73,10 @@ describe('env', () => {
   describe('#getComposeExecutable', () => {
     it('should return the correct lando-provided path on win32', () => {
       setPlatform('win32');
-      filesystem({'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker-compose-v1.exe': 'CODEZ'});
+      filesystem({'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker-compose.exe': 'CODEZ'});
       process.env.ProgramW6432 = 'C:\\Program Files';
       const composeExecutable = env.getComposeExecutable();
-      const value = path.win32.join(env.getDockerBinPath(), 'docker-compose-v1.exe');
+      const value = 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker-compose.exe';
       expect(composeExecutable).to.equal(value);
       resetPlatform();
       delete process.env.ProgramW6432;
@@ -82,20 +84,20 @@ describe('env', () => {
 
     it('should return the correct lando-provided path on linux', () => {
       setPlatform('linux');
-      filesystem({'/usr/share/lando/bin/docker-compose': 'CODEZ'});
+      filesystem({'/usr/bin/docker-compose': 'CODEZ'});
       const composeExecutable = env.getComposeExecutable();
-      expect(composeExecutable).to.equal('/usr/share/lando/bin/docker-compose');
+      expect(composeExecutable).to.equal('/usr/bin/docker-compose');
       filesystem.restore();
       resetPlatform();
     });
 
     it('should return the correct lando-provided path on darwin', () => {
       setPlatform('darwin');
-      filesystem({'/Applications/Docker.app/Contents/Resources/bin/docker-compose-v1/docker-compose': 'CODEZ'});
+      filesystem({'/usr/bin/docker-compose': 'CODEZ'});
       const composeExecutable = env.getComposeExecutable();
       expect(composeExecutable)
         .to
-        .equal('/Applications/Docker.app/Contents/Resources/bin/docker-compose-v1/docker-compose');
+        .equal('/usr/bin/docker-compose');
       filesystem.restore();
       resetPlatform();
     });
@@ -137,9 +139,9 @@ describe('env', () => {
 
     it('should return the correct lando-provided path on darwin', () => {
       setPlatform('darwin');
-      filesystem({'/Applications/Docker.app/Contents/Resources/bin/docker': 'CODEZ'});
+      filesystem({'/usr/bin/docker': 'CODEZ'});
       const dockerExecutable = env.getDockerExecutable();
-      expect(dockerExecutable).to.equal('/Applications/Docker.app/Contents/Resources/bin/docker');
+      expect(dockerExecutable).to.equal('/usr/bin/docker');
       filesystem.restore();
       resetPlatform();
     });

--- a/test/env.spec.js
+++ b/test/env.spec.js
@@ -57,6 +57,7 @@ describe('env', () => {
 
     it('should return the correct lando-provided path on linux', () => {
       setPlatform('linux');
+      filesystem({'/usr/bin/docker': 'CODEZ'});
       const dockerBinPath = env.getDockerBinPath();
       expect(dockerBinPath).to.equal('/usr/bin');
       resetPlatform();
@@ -64,8 +65,9 @@ describe('env', () => {
 
     it('should return the correct lando-provided path on darwin', () => {
       setPlatform('darwin');
+      filesystem({'/usr/local/bin/docker': 'CODEZ'});
       const dockerBinPath = env.getDockerBinPath();
-      expect(dockerBinPath).to.equal('/usr/bin');
+      expect(dockerBinPath).to.equal('/usr/local/bin');
       resetPlatform();
     });
   });

--- a/test/lando.spec.js
+++ b/test/lando.spec.js
@@ -45,15 +45,15 @@ describe('lando', () => {
   });
 
   describe('#bootstrap', () => {
-    it('should return a lando object with the default config', () => {
-      const lando = new Lando({logLevelConsole: 'warn'});
+    it('should return a lando object with the default config', function() {
+      const lando = new Lando({logLevelConsole: 'warning'});
       return lando.bootstrap().then(lando => {
         lando.config.userConfRoot.should.equal(os.tmpdir());
         lando.config.plugins.should.be.an('array').and.be.empty;
       });
     });
 
-    it('should mix envvars into config with set prefix', () => {
+    it('should mix envvars into config with set prefix', function() {
       process.env.JOURNEY_PRODUCT = 'steveperry';
       process.env.JOURNEY_MODE = 'rocknroll';
       const lando = new Lando({envPrefix: 'JOURNEY'});
@@ -67,7 +67,7 @@ describe('lando', () => {
       });
     });
 
-    it('should mix config files into config', () => {
+    it('should mix config files into config', function() {
       const srcRoot = path.resolve(__dirname, '..');
       // @TODO: the below should be mock-fs instead of the actual FS
       const lando = new Lando({

--- a/test/lando.spec.js
+++ b/test/lando.spec.js
@@ -46,6 +46,8 @@ describe('lando', () => {
 
   describe('#bootstrap', () => {
     it('should return a lando object with the default config', function() {
+      // eslint-disable-next-line no-invalid-this
+      this.timeout(45000);
       const lando = new Lando({logLevelConsole: 'warning'});
       return lando.bootstrap().then(lando => {
         lando.config.userConfRoot.should.equal(os.tmpdir());
@@ -54,6 +56,8 @@ describe('lando', () => {
     });
 
     it('should mix envvars into config with set prefix', function() {
+      // eslint-disable-next-line no-invalid-this
+      this.timeout(15000);
       process.env.JOURNEY_PRODUCT = 'steveperry';
       process.env.JOURNEY_MODE = 'rocknroll';
       const lando = new Lando({envPrefix: 'JOURNEY'});
@@ -68,6 +72,8 @@ describe('lando', () => {
     });
 
     it('should mix config files into config', function() {
+      // eslint-disable-next-line no-invalid-this
+      this.timeout(15000);
       const srcRoot = path.resolve(__dirname, '..');
       // @TODO: the below should be mock-fs instead of the actual FS
       const lando = new Lando({


### PR DESCRIPTION
* Use the same version detection code for all OSes;
* Do not look specifically for docker-compose-v1;
* Prefer `/usr/bin`
