### PR TITLE
chore(deps): Remove mkdirp

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const fs = require('fs');
 const jsonfile = require('jsonfile');
 const Log = require('./logger');
-const mkdirp = require('mkdirp');
 const NodeCache = require('node-cache');
 const os = require('os');
 const path = require('path');
@@ -21,7 +20,7 @@ class Cache extends NodeCache {
     this.log = log;
     this.cacheDir = cacheDir;
     // Ensure the cache dir exists
-    mkdirp.sync(this.cacheDir);
+    fs.mkdirSync(this.cacheDir, {recursive: true});
   };
 
   /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,9 +1,9 @@
 'use strict';
 
 // Modules
+const fs = require('fs');
 const _ = require('lodash');
 const dayjs = require('dayjs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 const serialize = require('winston/lib/winston/common').serialize;
 const util = require('util');
@@ -176,7 +176,7 @@ module.exports = class Log extends winston.Logger {
     // If we have a log path then let's add in some file transports
     if (logDir) {
       // Ensure the log dir actually exists
-      mkdirp.sync(logDir);
+      fs.mkdirSync(logDir, {recursive: true});
       // Add in our generic and error logs
       transports.push(new winston.transports.File({
         name: 'error-file',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,6 @@
 const _ = require('lodash');
 const copydir = require('copy-dir');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const parse = require('string-argv');
 const os = require('os');
 const path = require('path');
@@ -144,7 +143,7 @@ exports.moveConfig = (src, dest = os.tmpdir()) => {
   // We don't want to give the false impression that you can edit the JS
   const filter = (stat, filepath, filename) => (path.extname(filename) !== '.js');
   // Ensure to exists
-  mkdirp.sync(dest);
+  fs.mkdirSync(dest, {recursive: true});
   // Try to copy the assets over
   try {
     // @todo: why doesn't the below work for PLD?
@@ -159,7 +158,7 @@ exports.moveConfig = (src, dest = os.tmpdir()) => {
     const f = _.get(error, 'path');
 
     // Catch this so we can try to repair
-    if (code !== 'EISDIR' || syscall !== 'open' || !!mkdirp.sync(f)) {
+    if (code !== 'EISDIR' || syscall !== 'open' || !!fs.mkdirSync(f, {recursive: true})) {
       throw new Error(error);
     }
 

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -2,7 +2,6 @@
 
 // Modules
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const Log = require('./logger');
 const path = require('path');
 const yaml = require('js-yaml');
@@ -45,7 +44,7 @@ module.exports = class Yaml {
    */
   dump(file, data = {}) {
     // Make sure we have a place to store these files
-    mkdirp.sync(path.dirname(file));
+    fs.mkdirSync(path.dirname(file), {recursive: true});
     // Remove any properties that might be bad and dump
     data = JSON.parse(JSON.stringify(data));
     // And dump

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "eslint-plugin-vue": "^8.0.3",
     "leia-parser": "^0.4.0",
     "mocha": "^4.1.0",
-    "mock-fs": "https://github.com/pirog/mock-fs.git#256-ctxBindingAccess",
+    "mock-fs": "^5.2.0",
     "nyc": "^12.0.1",
     "pkg": "^5.3.1",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "js-yaml": "^3.4.6",
     "jsonfile": "^2.4.0",
     "lodash": "^4.17.21",
-    "mkdirp": "^0.5.1",
     "node-cache": "^4.1.1",
     "object-hash": "^1.1.8",
     "semver": "^7.3.8",

--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -4,7 +4,6 @@
 const _ = require('lodash');
 const ip = require('ip');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 
 // Default env values
@@ -63,9 +62,9 @@ module.exports = lando => {
   const caProject = `landocasetupkenobi38ahsoka${lando.config.instance}`;
   const sshDir = path.join(lando.config.home, '.ssh');
   // Ensure some dirs exist before we start
-  mkdirp.sync(caDir);
+  fs.mkdirSync(caDir, {recursive: true});
   if (lando.config.home) {
-    mkdirp.sync(sshDir);
+    fs.mkdirSync(sshDir, {recursive: true});
   }
 
   // Make sure we have a host-exposed root ca if we don't already

--- a/plugins/lando-proxy/app.js
+++ b/plugins/lando-proxy/app.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Modules
+const fs = require('fs');
 const _ = require('lodash');
-const mkdirp = require('mkdirp');
 const path = require('path');
 const utils = require('./lib/utils');
 const warnings = require('./lib/warnings');
@@ -69,7 +69,7 @@ module.exports = (app, lando) => {
       lando.log.verbose('proxy is ON.');
       lando.log.verbose('Setting the default proxy certificate %s', lando.config.proxyDefaultCert);
       // Create needed directories
-      mkdirp.sync(lando.config.proxyConfigDir);
+      fs.mkdirSync(lando.config.proxyConfigDir, {recursive: true});
       const files = [{
         path: path.join(lando.config.proxyConfigDir, 'default-certs.yaml'),
         data: {tls: {stores: {default: {defaultCertificate: {

--- a/plugins/lando-recipes/lib/options.js
+++ b/plugins/lando-recipes/lib/options.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 const utils = require('./../../../lib/utils');
 
@@ -138,7 +137,9 @@ exports.parseOptions = options => {
   // Get absolute path of destination
   options.destination = path.resolve(options.destination);
   // Create directory if needed
-  if (!fs.existsSync(options.destination)) mkdirp.sync(options.destination);
+  if (!fs.existsSync(options.destination)) {
+    fs.mkdirSync(options.destination, {recursive: true});
+  }
   // Set node working directory to the destination
   // @NOTE: is this still needed?
   process.chdir(options.destination);

--- a/scripts/yaml2json.js
+++ b/scripts/yaml2json.js
@@ -5,7 +5,6 @@
 const _ = require('lodash');
 const argv = require('yargs').argv;
 const fs = require('fs-extra');
-const mkdirp = require('mkdirp');
 const Log = require('./../lib/logger');
 const log = new Log({logLevelConsole: 'debug', logName: 'yaml2json'});
 const path = require('path');
@@ -37,7 +36,7 @@ const inputFilePaths = _(inputFiles)
 // Make sure output dir is dialed
 if (!fs.existsSync(outputDir)) {
   log.info('%s does not exists, creating it...', outputDir);
-  mkdirp.sync(outputDir);
+  fs.mkdirSync(outputDir, {recursive: true});
 }
 
 // Finalize inputs and outputs

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,9 +3919,10 @@ mocha@^4.1.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-"mock-fs@https://github.com/pirog/mock-fs.git#256-ctxBindingAccess":
-  version "4.7.0"
-  resolved "https://github.com/pirog/mock-fs.git#491fec84c10f5ca9676f2622dbcbd73ae598aaab"
+mock-fs@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.2.0.tgz#3502a9499c84c0a1218ee4bf92ae5bf2ea9b2b5e"
+  integrity sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR removes `mkdirp` package. The way Lando uses `mkdirp.sync()` is equivalent to the builtin `fs.mkdirSync()` with `{ recursive: true }` ~and a check for `EEXIST`~ (the check was required for the ancient `mock-fs` package - it has also been updated, so the check is no longer necessary).

Together with #27, this completely removes all versions of `mkdirp`.

Fewer ancient dependencies means fewer vulnerabilities.

Among other things, this slightly improves performance in WSL and virtualized environments: the native implementation does less I/O syscalls.
