### PR TITLE
chore(deps): Remove sudo-block

### DIFF
--- a/core/art.js
+++ b/core/art.js
@@ -359,14 +359,6 @@ exports.shareWait = () => [
 /*
  * Helper to show status of secret toggle
  */
-exports.sudoRun = () => [
-  chalk.red('Lando should never ever ever be run as root...'),
-  chalk.magenta(niceFont('like ever!!!', 'Small Slant')),
-].join(os.EOL);
-
-/*
- * Helper to show status of secret toggle
- */
 exports.tunnel = ({url, phase = 'pre'} = {}) => {
   switch (phase) {
     case 'pre':

--- a/lib/art.js
+++ b/lib/art.js
@@ -359,14 +359,6 @@ exports.shareWait = () => [
 /*
  * Helper to show status of secret toggle
  */
-exports.sudoRun = () => [
-  chalk.red('Lando should never ever ever be run as root...'),
-  chalk.magenta(niceFont('like ever!!!', 'Small Slant')),
-].join(os.EOL);
-
-/*
- * Helper to show status of secret toggle
- */
 exports.tunnel = ({url, phase = 'pre'} = {}) => {
   switch (phase) {
     case 'pre':

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -74,8 +74,7 @@ module.exports = class Cli {
    * lando.cli.checkPerms()
    */
   checkPerms() {
-    const sudoBlock = require('sudo-block');
-    sudoBlock(this.makeArt('sudoRun'));
+    /* Do nothing */
   };
 
   /*

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "semver": "^7.3.8",
     "shelljs": "^0.8.4",
     "string-argv": "0.1.1",
-    "sudo-block": "^2.0.0",
     "through": "^2.3.8",
     "transliteration": "^2.3.5",
     "uuid": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,7 +1352,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3119,11 +3119,6 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
-is-docker@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
-  integrity sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=
-
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -3234,11 +3229,6 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
-
-is-root@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
-  integrity sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -5292,15 +5282,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-sudo-block@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sudo-block/-/sudo-block-2.0.0.tgz#b0116035fb8b72bb3a4fee8499f52af8a9197d13"
-  integrity sha512-BtQhz9xtBrwznoyakSOqj9posQoQjeyN0guytNriU6CnAcjF18WkPaN45xM1tLkwNLRBFK7tZUQDIE+iEOzayg==
-  dependencies:
-    chalk "^2.1.0"
-    is-docker "^1.0.0"
-    is-root "^1.0.0"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
This PR removes `sudo-block` and its dependencies:
1. We do allow to run `vip dev-env` as `root` and it is probably too late to check that
2. We have never used `lando.cli.checkPerms()` anyway.
