### PR TITLE
chore(deps): Update js-yaml from 3.4.6 to 4.1.0

### DIFF
--- a/bin/lando.js
+++ b/bin/lando.js
@@ -59,7 +59,7 @@ if (!hconf[binPath] || (landoConfig.version !== hconf[binPath].version)) {
     }))
     .filter(plugin => fs.existsSync(plugin.manifest))
     .map(plugin => Object.assign(plugin, { // eslint-disable-line
-      manifest: yaml.safeLoad(fs.readFileSync(plugin.manifest)),
+      manifest: yaml.load(fs.readFileSync(plugin.manifest)),
       pjson: fs.existsSync(plugin.pjson) ? require(plugin.pjson) : {},
     }))
     .map(plugin => ({

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -31,7 +31,7 @@ const loadCacheFile = file => {
  */
 const loadLandoFile = file => {
   try {
-    return yaml.safeLoad(fs.readFileSync(file));
+    return yaml.load(fs.readFileSync(file));
   } catch (e) {
     throw new Error(`There was a problem with parsing ${file}. Ensure it is valid YAML! ${e}`);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -210,7 +210,7 @@ exports.loadFiles = files => _(files)
   .filter(source => fs.existsSync(source) || fs.existsSync(source.file))
   // If the file is just a string lets map it to an object
   .map(source => {
-    return _.isString(source) ? {file: source, data: yaml.safeLoad(fs.readFileSync(source)) || {}} : source;
+    return _.isString(source) ? {file: source, data: yaml.load(fs.readFileSync(source)) || {}} : source;
   })
   // Add on the root directory for mapping purposes
   .map(source => _.merge({}, source, {root: path.dirname(source.file)}))

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -27,7 +27,7 @@ module.exports = class Yaml {
    */
   load(file) {
     try {
-      return yaml.safeLoad(fs.readFileSync(file));
+      return yaml.load(fs.readFileSync(file));
     } catch (e) {
       this.log.error('Problem parsing %s with %s', file, e.message);
     }
@@ -48,7 +48,7 @@ module.exports = class Yaml {
     // Remove any properties that might be bad and dump
     data = JSON.parse(JSON.stringify(data));
     // And dump
-    fs.writeFileSync(file, yaml.safeDump(data));
+    fs.writeFileSync(file, yaml.dump(data));
     // Log and return filename
     return file;
   };

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "inquirer": "^6.2.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "ip": "^1.1.8",
-    "js-yaml": "^3.4.6",
+    "js-yaml": "^4.1.0",
     "jsonfile": "^2.4.0",
     "lodash": "^4.17.21",
     "node-cache": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,6 +3337,13 @@ js-yaml@^3.13.1, js-yaml@^3.4.6:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"


### PR DESCRIPTION
This PR updates `js-yaml` to 4.1.0 and fixes the code affected by the [breaking changes](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#400---2021-01-03).

In additional to paying technical debt, this will reduce the number of dependencies for `vip-cli`:
* `vip-cli` uses `js-yaml` 4.1.0;
* The remaining lando plugins reference `js-yaml` 3.x in their dependencies but do not use it, but this can be solved with the `overrides` in `package.json`;
* Switching to the latest `js-yaml` removes the outdated `argparse@1.0.7` (2.0.1 is used by another package as well), `sprintf-js@1.0.3`, and `esprima@4.0.1`.
