### PR TITLE
Init Only support

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -538,4 +538,12 @@ module.exports = class App {
     const regex = new RegExp(`${this.project}${sep}(.*)${sep}1`);
     return id.replace(regex, '$1');
   };
+
+  isInitOnlyService(service) {
+    const initOnlyServices = this.info
+      .filter(serviceInfo => serviceInfo.config && serviceInfo.config.initonly)
+      .map(serviceInfo => serviceInfo.service);
+
+    return initOnlyServices.includes(service);
+  }
 };

--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -70,7 +70,8 @@ module.exports = (app, lando) => {
   app.events.on('post-init', () => {
     const buildServices = _.get(app, 'opts.services', app.services);
     app.log.verbose('refreshing certificates...', buildServices);
-    app.events.on('post-start', 9999, () => lando.Promise.each(buildServices, service => {
+    const servicesToRefreshCertificates = buildServices.filter(service => !app.isInitOnlyService(service));
+    app.events.on('post-start', 9999, () => lando.Promise.each(servicesToRefreshCertificates, service => {
       return app.engine.run({
         id: app.getServiceContainerId(service),
         cmd: 'mkdir -p /certs && /helpers/refresh-certs.sh > /certs/refresh.log',

--- a/plugins/lando-networking/app.js
+++ b/plugins/lando-networking/app.js
@@ -14,6 +14,7 @@ module.exports = (app, lando) => {
     const landonet = lando.engine.getNetwork(lando.config.networkBridge);
     // List all our app containers
     return lando.engine.list({project: app.project})
+    .filter(container => !app.isInitOnlyService(container.service))
     // Go through each container
     .map(container => {
       // Define the internal aliae


### PR DESCRIPTION
This change adds support for `initonly` config in lando file.:
```
 vip-mu-plugins:
    type: compose
    config:
      initonly: true
```

By default lando expects all the services to stick around forever. So it does things like installs certificates to them `post-start` however if we want to have services that only inject code at the start we need a way to tell lando that these should be treated as such.

Without this change lando bootstrap fails if service is not around.

