### PR TITLE
fix: Compatibility with docker-compose v2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -199,18 +199,17 @@ exports.shellEscape = (command, wrap = false, args = process.argv.slice(3)) => {
 /*
  * Extracts some docker inspect data and translates it into useful lando things
  */
-exports.toLandoContainer = ({Labels, Id, Status}) => {
+exports.toLandoContainer = ({Names, Labels, Id, Status}) => {
   // Get name of docker container.
   const app = Labels['com.docker.compose.project'];
   const service = Labels['com.docker.compose.service'];
-  const num = Labels['com.docker.compose.container-number'];
   const lando = Labels['io.lando.container'];
   const special = Labels['io.lando.service-container'];
   // Build generic container.
   return {
     id: Id,
     service: service,
-    name: [app, service, num].join('_'),
+    name: Names[0].slice(1),
     app: (special !== 'TRUE') ? app : '_global_',
     src: (Labels['io.lando.src']) ? Labels['io.lando.src'].split(',') : 'unknown',
     kind: (special !== 'TRUE') ? 'app' : 'service',

--- a/test/docker.spec.js
+++ b/test/docker.spec.js
@@ -24,6 +24,7 @@ const dummyContainer = (overrides = {}) => {
     {
       Id: '8675309',
       app: 'Death Star',
+      Names: ['/Death Star_Exhaust Port_73'],
       Labels: {
         'com.docker.compose.project': 'Death Star',
         'com.docker.compose.service': 'Exhaust Port',


### PR DESCRIPTION
`utils.toLandoContainer()` forcefully uses `_` as a separator in container names. This makes `lando.engine.exists({id: proxyContainer})` in `lando-networking` plugin resolve with `false` when using docker-compose v2, leading to hard-to-reproduce interesting bugs.
