### PR TITLE
ci: Use latest OSes for unit tests

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
-          - ubuntu-20.04
-          - macos-10.15
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
         node-version:
-          - '14'
+          - 'lts/*'
     steps:
 
       # Install deps and cache


### PR DESCRIPTION
* `macos-10.15` is no longer available
* Node 14 is past EOL
