### PR TITLE
fix: network.external.name is deprecated in favor of network.name

### DIFF
--- a/plugins/lando-proxy/app.js
+++ b/plugins/lando-proxy/app.js
@@ -171,7 +171,7 @@ module.exports = (app, lando) => {
               `${lando.config.userConfRoot}/scripts/proxy-certs.sh:/scripts/100-proxy-certs`,
             ],
           }),
-          networks: {'lando_proxyedge': {external: {name: lando.config.proxyNet}}},
+          networks: {'lando_proxyedge': {name: lando.config.proxyNet}},
           volumes: _.set({}, proxyVolume, {external: true}),
         };
       })


### PR DESCRIPTION
Steps to reproduce:
1. Ensure you are running docker-compose v2
2. Create and start an environment
3. Observe `network lando_proxyedge: network.external.name is deprecated in favor of network.name`
4. Apply the patch and restart the environment
5. The warning should disappear.
