### PR TITLE
fix: compatibility with docker-compose v2.19.x

### DIFF
--- a/plugins/lando-proxy/app.js
+++ b/plugins/lando-proxy/app.js
@@ -171,7 +171,7 @@ module.exports = (app, lando) => {
               `${lando.config.userConfRoot}/scripts/proxy-certs.sh:/scripts/100-proxy-certs`,
             ],
           }),
-          networks: {'lando_proxyedge': {name: lando.config.proxyNet}},
+          networks: {'lando_proxyedge': {name: lando.config.proxyNet, external: true}},
           volumes: _.set({}, proxyVolume, {external: true}),
         };
       })


### PR DESCRIPTION
This PR‌ fixes the issue with `docker-compose` v2.19.x:

```
WARN[0000] a network with name vip-dev-env-proxy_edge exists but was not created for project "viplocal".
Set `external: true` to use an existing network 
network vip-dev-env-proxy_edge was found but has incorrect label com.docker.compose.network set to "edge"
```

Ref: https://github.com/docker/compose/pull/10612/files#diff-1f4d596600c620b3df55dbfbc63e50a6f43b356865fae411c553d0937fbb6d91R1110