### PR TITLE
fix: try to make error messages more informative

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -7,7 +7,6 @@ const Log = require('./logger');
 const _shell = require('shelljs');
 const path = require('path');
 const parse = require('yargs-parser');
-const os = require('os');
 const Promise = require('./promise');
 const stdoutStream = require('through');
 const stderrStream = require('through');
@@ -157,7 +156,8 @@ module.exports = class Shell {
       this.log.silly('process %s had output', id, {stdout, stderr});
       // Return
       _.remove(this.running, proc => proc.id === id);
-      return (code !== 0) ? Promise.reject(new Error(`${cmd} failed with exit code ${code}\n:${stderr}`)) : Promise.resolve(stdout);
+      const msg = `${cmd} failed with exit code ${code}\n:${stderr}`;
+      return (code !== 0) ? Promise.reject(new Error(msg)) : Promise.resolve(stdout);
     });
   };
 

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -157,7 +157,7 @@ module.exports = class Shell {
       this.log.silly('process %s had output', id, {stdout, stderr});
       // Return
       _.remove(this.running, proc => proc.id === id);
-      return (code !== 0) ? Promise.reject(new Error(stderr)) : Promise.resolve(stdout);
+      return (code !== 0) ? Promise.reject(new Error(`${cmd} failed with exit code ${code}\n:${stderr}`)) : Promise.resolve(stdout);
     });
   };
 

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -149,7 +149,9 @@ module.exports = class Shell {
     // Assess the results
     .then(({code, stdout, stderr}) => {
       // if this is an error and stderr is empty use the last few lines of STDOUT
-      if (code !== 0 && _.isEmpty(stderr)) stderr = _.trim(_.last(_.compact(stdout.split(os.EOL))));
+      if (code !== 0 && _.isEmpty(stderr)) {
+        stderr = stdout.trim();
+      }
       // Log
       this.log.debug('process %s finished with exit code %s', id, code);
       this.log.silly('process %s had output', id, {stdout, stderr});


### PR DESCRIPTION
Right now, log messages are sometimes very uninformative, and all we have is something like

```
Error at /.../lib/node_modules/@automattic/vip/node_modules/lando/lib/shell.js:158:44 From previous event: at Shell.sh...
```

(more details are in Pendo).

This PR adds more information to the error message so that we at least know wtf is going on.
