### PR TITLE
security: fix CVE-2023-42282 in ip

### DIFF
--- a/examples/lando-101/README.md
+++ b/examples/lando-101/README.md
@@ -61,7 +61,7 @@ cd lando-101
 cp ../.lando.tooling.yml .lando.yml
 lando rebuild -y
 lando composer require squizlabs/php_codesniffer
-lando phpcs --version |grep squiz
+lando phpcs --version | grep -i squiz
 lando destroy -y
 ```
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "glob": "^7.1.3",
     "inquirer": "^6.2.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
-    "ip": "^1.1.8",
+    "ip": "^1.1.9",
     "js-yaml": "^4.1.0",
     "jsonfile": "^2.4.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,10 +2478,10 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ip@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
-  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
+ip@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
+  integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
 
 is-binary-path@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Ref: GHSA-78xj-cgh5-2h22

The only function Lando uses from `ip` is `ip.address()`.
