### PR TITLE
refactor: remove docker autostart/stop code

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -306,16 +306,6 @@ module.exports = class Cli {
               console.error(this.makeArt('noDockerDep', 'docker-compose'));
               throw Error('docker-compose could not be located!');
             }
-            // Show a message saying we are starting docker if its not up, we can also do this async
-            // because the auto-start mechanism is downstream, this is just to surface a message
-            lando.engine.daemon.isUp().then(isUp => {
-              if (!isUp) {
-                lando.log.warn('docker is not running!');
-                console.log('Starting docker up before we begin... please wait...');
-              } else {
-                lando.log.debug('docker is running.');
-              }
-            });
           }
         })
         /**

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -11,24 +11,6 @@ const Shell = require('./shell');
 const shell = new Shell();
 
 // Constants
-const macOSBase = '/Applications/Docker.app';
-
-/*
- * Get services wrapper
- */
-const buildDockerCmd = cmd => {
-  switch (process.platform) {
-    case 'darwin':
-      return ['open', macOSBase];
-    case 'linux':
-      return ['sudo', 'service', 'docker'].concat(cmd);
-    case 'win32':
-      const base = process.env.ProgramW6432 || process.env.ProgramFiles;
-      const dockerBin = base + '\\Docker\\Docker\\Docker Desktop.exe';
-      return ['cmd', '/C', `"${dockerBin}"`];
-  }
-};
-
 const composeV1Separator = '_';
 const composeV2Separator = '-';
 
@@ -68,30 +50,7 @@ module.exports = class LandoDaemon {
      * @since 3.0.0
      * @event pre_engine_up
      */
-    return this.events.emit('pre-engine-up').then(() => {
-      // Automatically return true if we are in the GUI and on linux because
-      // this requires SUDO and because the daemon should always be running on nix
-      if (this.context !== 'node' && process.platform === 'linux') return Promise.resolve(true);
-      // Turn it on if we can
-      return this.isUp().then(isUp => {
-        if (!isUp) {
-          const retryOpts = {max: 25, backoff: 1000};
-          return shell.sh(buildDockerCmd('start'))
-          .catch(err => {
-            throw Error('Could not automatically start the Docker Daemon. Please manually start it to continue.');
-          })
-          // Likely need to retry until start command completes all good
-          .retry(() => this.isUp().then(isUp => (!isUp) ? Promise.reject() : Promise.resolve()), retryOpts)
-          // Fail if retry is no good
-          .catch(err => {
-            throw Error('Could not automatically start the Docker Daemon. Please manually start it to continue.');
-          })
-          // Engine is good!
-          .then(() => this.log.info('engine activated.'));
-        }
-      });
-    })
-
+    return this.events.emit('pre-engine-up')
     /*
      * Not officially documented event that allows you to do some things after
      * the docker engine is booted up.
@@ -111,29 +70,6 @@ module.exports = class LandoDaemon {
      * @event pre_engine_down
      */
     return this.events.emit('pre-engine-down')
-    .then(() => {
-      // Automatically return true if we are in browsery context and on linux because
-      // this requires SUDO and because the daemon should always be running on nix
-      if (this.context !== 'node' && process.platform === 'linux') return Promise.resolve(true);
-      // Automatically return if we are on Windows or Darwin because we don't
-      // ever want to automatically turn the VM off since users might be using
-      // D4M/W for other things.
-      //
-      // For now we will be shutting down any services via relevant event hooks
-      // that bind to critical/common ports on 127.0.0.1/localhost e.g. 80/443/53
-      //
-      // @todo: When/if we can run our own isolated docker daemon we can change
-      // this back.
-      if (process.platform === 'win32' || process.platform === 'darwin') return Promise.resolve(true);
-      // Shut provider down if its status is running.
-      return this.isUp(this.log, this.cache, this.docker).then(isUp => {
-        if (isUp) return shell.sh(buildDockerCmd('stop'), {mode: 'collect'});
-      })
-      // Wrap errors.
-      .catch(err => {
-        throw new Error(err, 'Error while shutting down.');
-      });
-    })
     /*
      * Event that allows you to do some things after the docker engine is booted
      * up.
@@ -150,19 +86,8 @@ module.exports = class LandoDaemon {
    * this means we also assume whatever necessary installation checks have been
    * performed and dockers existence verified
    */
-  isUp(log = this.log, cache = this.cache, docker = this.docker) {
-    // Auto return if cached and true
-    if (cache.get('engineup') === true) return Promise.resolve(true);
-    // Return true if we get a zero response and cache the result
-    return shell.sh([`"${docker}"`, 'info']).then(() => {
-      log.debug('engine is up.');
-      cache.set('engineup', true, {ttl: 5});
-      return Promise.resolve(true);
-    })
-    .catch(error => {
-      log.debug('engine is down with error', error);
-      return Promise.resolve(false);
-    });
+  isUp() {
+    return Promise.resolve(true);
   };
 
   /*


### PR DESCRIPTION
This PR removes the Docker auto-start/stop code. It never worked anyway because we checked for Docker connectivity at the app startup.

This also saves us a call to `docker info`.