### PR TITLE
fix: remove the call to undefined `windowsHome()`

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -117,7 +117,6 @@ const getOClifHome = () => {
       return process.env.HOME
         || (process.env.HOMEDRIVE && process.env.HOMEPATH && path.join(process.env.HOMEDRIVE, process.env.HOMEPATH))
         || process.env.USERPROFILE
-        || windowsHome()
         || os.homedir()
         || os.tmpdir();
   }


### PR DESCRIPTION
`getOClifHome()` references non-existing `windowsHome()` function. This PR removes that call.
