### PR TITLE
Remove 'version' from ComposeService, drop support for composer v1

### DIFF
--- a/.github/workflows/pr-core-tests.yml
+++ b/.github/workflows/pr-core-tests.yml
@@ -9,6 +9,7 @@ jobs:
     env:
       TERM: xterm
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -42,7 +43,10 @@ jobs:
         run: yarn install --prefer-offline --frozen-lockfile
 
       - name: Install docker-compose
-        run: sudo wget -q https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
+        run: |
+          REPO="docker/compose"
+          LATEST_RELEASE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" --silent "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)
+          sudo curl -L "https://github.com/${REPO}/releases/download/${LATEST_RELEASE}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && sudo chmod 0755 /usr/local/bin/docker-compose
 
       # - name: Install via hyperdrive if above is bad
       - name: Disable usage and error reporting
@@ -60,6 +64,8 @@ jobs:
         run: |
           lando version
           lando config
+          docker -v
+          docker-compose -v
 
       # This block should eventually become use lando/actions-leia@v2
       - name: Generate tests

--- a/.github/workflows/pr-db-tools-tests.yml
+++ b/.github/workflows/pr-db-tools-tests.yml
@@ -33,7 +33,10 @@ jobs:
         run: yarn install --prefer-offline --frozen-lockfile
 
       - name: Install docker-compose
-        run: sudo wget -q https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
+        run: |
+          REPO="docker/compose"
+          LATEST_RELEASE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" --silent "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)
+          sudo curl -L "https://github.com/${REPO}/releases/download/${LATEST_RELEASE}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && sudo chmod 0755 /usr/local/bin/docker-compose
 
       # - name: Install via hyperdrive if above is bad
       - name: Disable usage and error reporting

--- a/.github/workflows/pr-django-tests.yml
+++ b/.github/workflows/pr-django-tests.yml
@@ -32,7 +32,10 @@ jobs:
         run: yarn install --prefer-offline --frozen-lockfile
 
       - name: Install docker-compose
-        run: sudo wget -q https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
+        run: |
+          REPO="docker/compose"
+          LATEST_RELEASE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" --silent "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)
+          sudo curl -L "https://github.com/${REPO}/releases/download/${LATEST_RELEASE}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && sudo chmod 0755 /usr/local/bin/docker-compose
 
       # - name: Install via hyperdrive if above is bad
       - name: Disable usage and error reporting

--- a/.github/workflows/pr-plugins-installed.yml
+++ b/.github/workflows/pr-plugins-installed.yml
@@ -64,7 +64,10 @@ jobs:
         run: yarn install --prefer-offline --frozen-lockfile
 
       - name: Install docker-compose
-        run: sudo wget -q https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
+        run: |
+          REPO="docker/compose"
+          LATEST_RELEASE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" --silent "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)
+          sudo curl -L "https://github.com/${REPO}/releases/download/${LATEST_RELEASE}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && sudo chmod 0755 /usr/local/bin/docker-compose
 
       # - name: Install via hyperdrive if above is bad
       - name: Disable usage and error reporting

--- a/config.yml
+++ b/config.yml
@@ -6,18 +6,18 @@ mode: cli
 
 dockerSupportedVersions:
   compose:
-    min: "1.23.0"
-    max: "1.30.0"
+    min: "2.0.0"
+    max: "2.99.99"
     link:
       linux: https://docs.docker.com/compose/install/#install-compose-on-linux-systems
   desktop:
-    min: "2.1.0.0"
-    max: "3.6.99"
+    min: "4.0.0"
+    max: "4.99.99"
     link:
       darwin: https://docs.docker.com/docker-for-mac/release-notes/
       win32: https://docs.docker.com/docker-for-windows/release-notes/
   engine:
-    min: "18.09.3"
+    min: "26.99.9"
     max: "20.10.99"
     link:
       linux: https://docs.docker.com/engine/install/

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -43,15 +43,15 @@ Run the following commands to verify things work as expected
 
 ```bash
 # Should merge in all Landofiles correctly
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web2_1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-log-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web2-1
 
 # Should merge in all Landofiles correctly even if we are down a directory
 cd docker-compose
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web2_1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-log-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web2-1
 cd ..
 
 # Should load environment files from all Landofiles
@@ -104,9 +104,9 @@ lando info --format json
 lando info --path "[0]" | grep service | wc -l | grep 1
 
 # Should list this apps containers
-lando list | grep landobase_log_1
-lando list | grep landobase_web_1
-lando list | grep landobase_web2_1
+lando list | grep landobase-log-1
+lando list | grep landobase-web-1
+lando list | grep landobase-web2-1
 
 # Should output JSON in lando list without error
 lando list --format json
@@ -118,8 +118,8 @@ lando list --path "landobase" | grep landobase
 lando logs
 
 # Should return only logs for the specified service
-lando logs -s web2 | grep log_1 || echo $? | grep 1
-lando logs --service web2 | grep log_1 || echo $? | grep 1
+lando logs -s web2 | grep log-1 || echo $? | grep 1
+lando logs --service web2 | grep log-1 || echo $? | grep 1
 
 # Should run a command as the LANDO_WEBROOT_USER by default
 lando ssh -s web2 -c "id | grep \\\$LANDO_WEBROOT_USER"
@@ -139,23 +139,23 @@ docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 0
 
 # Should rebuild the services without errors
 lando rebuild -y
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web2_1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-log-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web2-1
 
 # Should only rebuild the specified services
 lando rebuild -y --service web2
 lando rebuild -y -s web2
-docker ps --latest | grep landobase_web2_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web2_1
+docker ps --latest | grep landobase-web2-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-log-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web2-1
 
 # Should restart the services without errors
 lando restart
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web_1
-docker ps --filter label=com.docker.compose.project=landobase | grep landobase_web2_1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-log-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web-1
+docker ps --filter label=com.docker.compose.project=landobase | grep landobase-web2-1
 
 # Should have non-numeric keys in LANDO_INFO
 lando php info.php

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -69,12 +69,12 @@ curl http://object-format.lndo.site | grep X-Lando-Test-Ssl || echo $? | grep 1
 curl -k https://object-format.lndo.site | grep X-Lando-Test-Ssl | grep on
 
 # Should generate a default certs config file and put it in the right place
-docker exec landoproxyhyperion5000gandalfedition_proxy_1 cat /proxy_config/default-certs.yaml | grep certFile | grep /certs/cert.crt
-docker exec landoproxyhyperion5000gandalfedition_proxy_1 cat /proxy_config/default-certs.yaml | grep keyFile | grep /certs/cert.key
+docker exec landoproxyhyperion5000gandalfedition-proxy-1 cat /proxy_config/default-certs.yaml | grep certFile | grep /certs/cert.crt
+docker exec landoproxyhyperion5000gandalfedition-proxy-1 cat /proxy_config/default-certs.yaml | grep keyFile | grep /certs/cert.key
 
 # Should generate proxy cert files and move them into the right location as needed
-docker exec landoproxy_web3_1 cat /proxy_config/web3.landoproxy.yaml| grep certFile | grep "/lando/certs/web3.landoproxy.crt"
-docker exec landoproxy_web3_1 cat /proxy_config/web3.landoproxy.yaml| grep keyFile | grep "/lando/certs/web3.landoproxy.key"
+docker exec landoproxy-web3-1 cat /proxy_config/web3.landoproxy.yaml| grep certFile | grep "/lando/certs/web3.landoproxy.crt"
+docker exec landoproxy-web3-1 cat /proxy_config/web3.landoproxy.yaml| grep keyFile | grep "/lando/certs/web3.landoproxy.key"
 ```
 
 Destroy tests

--- a/examples/scanner/README.md
+++ b/examples/scanner/README.md
@@ -23,10 +23,10 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should set 80,443 in io.lando.http-ports label by default
-docker inspect landoscanner_scanme_1 | grep io.lando.http-ports | grep "80,443"
+docker inspect landoscanner-scanme-1 | grep io.lando.http-ports | grep "80,443"
 
 # Should add an extra port to io.lando.http-ports if specified
-docker inspect landoscanner_moreports_1 | grep io.lando.http-ports | grep "80,443,8888"
+docker inspect landoscanner-moreports-1 | grep io.lando.http-ports | grep "80,443,8888"
 ```
 
 Destroy tests

--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -39,8 +39,8 @@ lando rebuild -y
 # Should rerun build steps even if containers are manually removed and stuff
 lando destroy -y
 lando start -y
-docker rm -f landoservices_nginx_1
-docker rm -f landoservices_appserver_1
+docker rm -f landoservices-nginx-1
+docker rm -f landoservices-appserver-1
 lando start -y
 lando ssh -s appserver -c "vim --version"
 lando ssh -s appserver -c "cat /var/www/build.txt"

--- a/examples/services/php/Dockerfile
+++ b/examples/services/php/Dockerfile
@@ -1,3 +1,5 @@
 FROM php:7.1-fpm-alpine
 
 ENV CUSTOM PIROG
+
+RUN apk add --no-cache shadow

--- a/lib/app.js
+++ b/lib/app.js
@@ -29,8 +29,6 @@ const loadPlugins = (app, lando) => Promise.resolve(app.plugins.registry)
   // Merge minotaur
   .each(result => _.merge(app, result));
 
-const defaultComposeSeparator = '_';
-
 /**
  * The class to instantiate a new App
  *
@@ -520,13 +518,11 @@ module.exports = class App {
   };
 
   getServiceContainerId(service) {
-    const sep = this._lando && this._lando.config && this._lando.config.composeSeparator || defaultComposeSeparator;
-    return `${this.project}${sep}${service}${sep}1`;
+    return `${this.project}-${service}-1`;
   };
 
   getServiceFromContainerId(id) {
-    const sep = this._lando && this._lando.config && this._lando.config.composeSeparator || defaultComposeSeparator;
-    const regex = new RegExp(`${this.project}${sep}(.*)${sep}1`);
+    const regex = new RegExp(`${this.project}-(.*)-1`);
     return id.replace(regex, '$1');
   };
 };

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -56,9 +56,8 @@ const engineRunner = (config, command) => (argv, lando) => {
   const app = lando.cache.get(path.basename(config.composeCache));
   app.config = config;
   app.events = new AsyncEvents(lando.log);
-  const sep = lando.config.composeSeparator;
-  app.getServiceContainerId = service => `${app.project}${sep}${service}${sep}1`;
-  app.getServiceFromContainerId = id => id.replace(new RegExp(`${app.project}${sep}(.*)${sep}1`), '$1');
+  app.getServiceContainerId = service => `${app.project}-${service}-1`;
+  app.getServiceFromContainerId = id => id.replace(new RegExp(`${app.project}-(.*)-1`), '$1');
   // Load only what we need so we don't pay the appinit penalty
   const utils = require('./../plugins/lando-tooling/lib/utils');
   const buildTask = require('./../plugins/lando-tooling/lib/build');

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -10,10 +10,6 @@ const Promise = require('./promise');
 const Shell = require('./shell');
 const shell = new Shell();
 
-// Constants
-const composeV1Separator = '_';
-const composeV2Separator = '-';
-
 /*
  * Creates a new Daemon instance.
  */
@@ -103,16 +99,4 @@ module.exports = class LandoDaemon {
       engine: _.trim(data[0]),
     }));
   };
-
-  getComposeSeparator() {
-    return this.compose ? new Promise(resolve => {
-      const semver = require('semver');
-      this.getVersions().then(versions => {
-        const isComposeV1 = semver.lt(versions.compose || '1.0.0', '2.0.0');
-
-        const composeSeparator = isComposeV1 ? composeV1Separator : composeV2Separator;
-        resolve(composeSeparator);
-      });
-    }) : Promise.resolve(composeV1Separator);
-  }
 };

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -201,8 +201,8 @@ module.exports = class Engine {
    * @example
    *
    * // Check to see if our app's web service is running
-   * return lando.engine.isRunning('myapp_web_1').then(isRunning) {
-   *   lando.log.info('Container %s is running: %s', 'myapp_web_1', isRunning);
+   * return lando.engine.isRunning('myapp-web-1').then(isRunning) {
+   *   lando.log.info('Container %s is running: %s', 'myapp-web-1', isRunning);
    * });
    */
   isRunning(data) {
@@ -292,11 +292,11 @@ module.exports = class Engine {
    * @example
    *
    * // Run composer install on the appserver container for an app called myapp
-   * return lando.engine.run({id: 'myapp_appserver_1', cmd: ['composer', 'install']});
+   * return lando.engine.run({id: 'myapp-appserver-1', cmd: ['composer', 'install']});
    *
    * // Drop into an interactive bash shell on the database continer for an app called myapp
    * return lando.engine.run({
-   *   id: 'myapp_database_1',
+   *   id: 'myapp-database-1',
    *   cmd: ['bash'],
    *   opts: {
    *     mode: 'attach'

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -13,7 +13,7 @@ const dockerCompose = class ComposeService {
   constructor(id, info = {}, ...sources) {
     this.id = id;
     this.info = info;
-    this.data = _(sources).map(source => _.merge({}, source, {version: '3.6'})).value();
+    this.data = _(sources).map(source => _.merge({}, source, {})).value();
   };
 };
 

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -106,12 +106,6 @@ const bootstrapEngine = lando => {
   lando.utils = _.merge({}, require('./utils'), require('./config'));
 
 
-  const separatorPromise = new Promise(resolve => {
-    lando.engine.daemon.getComposeSeparator().then(sep => {
-      lando.config.composeSeparator = sep;
-      resolve();
-    });
-  });
   // Auto move and make executable any scripts
   const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {
     if (fs.existsSync(plugin.scripts)) {
@@ -122,7 +116,7 @@ const bootstrapEngine = lando => {
     }
   });
 
-  return Promise.all([pluginPromise, separatorPromise]);
+  return Promise.all([pluginPromise]);
 };
 
 /*

--- a/plugins/lando-core/scripts/user-perm-helpers.sh
+++ b/plugins/lando-core/scripts/user-perm-helpers.sh
@@ -49,17 +49,17 @@ reset_user() {
   if getent group "$HOST_GID" 1>/dev/null 2>/dev/null; then
     HOST_GROUP=$(getent group "$HOST_GID" | cut -d: -f1)
   fi
-  if [ "$DISTRO" = "alpine" ]; then
+  if command -v usermod > /dev/null 2>&1 && command -v groupmod > /dev/null 2>&1; then
+    usermod -o -u "$HOST_UID" "$USER" 2>/dev/null
+    groupmod -g "$HOST_GID" "$GROUP" 2>/dev/null || true
+    usermod -g "$HOST_GID" "$USER" 2>/dev/null || true
+    usermod -a -G "$GROUP" "$USER" 2>/dev/null || true
+  else
     deluser "$USER" 2>/dev/null
     addgroup -g "$HOST_GID" "$GROUP" 2>/dev/null | addgroup "$GROUP" 2>/dev/null
     addgroup -g "$HOST_GID" "$HOST_GROUP" 2>/dev/null
     adduser -u "$HOST_UID" -G "$HOST_GROUP" -h /var/www -D "$USER" 2>/dev/null
     adduser "$USER" "$GROUP" 2>/dev/null
-  else
-    usermod -o -u "$HOST_UID" "$USER" 2>/dev/null
-    groupmod -g "$HOST_GID" "$GROUP" 2>/dev/null || true
-    usermod -g "$HOST_GID" "$USER" 2>/dev/null || true
-    usermod -a -G "$GROUP" "$USER" 2>/dev/null || true
   fi;
   # If this mapping is incorrect lets abort here
   if [ "$(id -u $USER)" != "$HOST_UID" ]; then

--- a/plugins/lando-events/lib/utils.js
+++ b/plugins/lando-events/lib/utils.js
@@ -43,7 +43,7 @@ exports.events2Runz = (cmds, app, data = {}) => _.map(cmds, cmd => {
   }
   // Add the build command
   return {
-    id: `${app.project}_${service}_1`,
+    id: `${app.project}-${service}-1`,
     cmd: ['/bin/sh', '-c', _.isArray(command) ? command.join(' ') : command],
     compose: app.compose,
     project: app.project,

--- a/plugins/lando-proxy/index.js
+++ b/plugins/lando-proxy/index.js
@@ -51,8 +51,7 @@ module.exports = lando => {
   });
 
   lando.events.on('post-bootstrap-engine', () => {
-    const sep = lando.config.composeSeparator;
-    lando.config.proxyContainer = `${lando.config.proxyName}${sep}proxy${sep}1`;
+    lando.config.proxyContainer = `${lando.config.proxyName}-proxy-1`;
   });
 
   // Return config defaults to rebase

--- a/plugins/lando-recipes/lib/build.js
+++ b/plugins/lando-recipes/lib/build.js
@@ -55,7 +55,7 @@ exports.runDefaults = (lando, options) => {
   const project = `${lando.config.product}init` + utils.dockerComposify(options.name);
   // Return
   return {
-    id: `${project}_init_1`,
+    id: `${project}-init-1`,
     project,
     user: 'www-data',
     compose: initFiles,


### PR DESCRIPTION
'version' key in Compose was deprecated for a while, but now it also throws an annoying WARN[0000] version is obsolete. 

This PR addresses the issue by removing `version from the ComposeService, which subsequently removes it from each generated compose file.