### PR TITLE
feat: add support for the `compose` plugin

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -135,14 +135,25 @@ exports.buildConfig = options => {
   return config;
 };
 
-/*
+/**
  * Helper for docker compose
  * @TODO: eventually this needs to live somewhere else so we can have a better
  * default engine instantiation
+ *
+ * @param {Shell} shell
+ * @param {string} bin
+ * @param {string} cmd
+ * @param {Object} datum
+ * @param {string} dockerBin
+ * @param {Object} versions
+ * @return {Promise<string>}
  */
-exports.dc = (shell, bin, cmd, {compose, project, opts = {}}) => {
+exports.dc = (shell, bin, cmd, {compose, project, opts = {}}, dockerBin, versions) => {
   const dockerCompose = require('./compose');
   const run = dockerCompose[cmd](compose, project, opts);
+  if (versions.composePlugin) {
+    return shell.sh([dockerBin, 'compose'].concat(run.cmd), run.opts);
+  }
   return shell.sh([bin].concat(run.cmd), run.opts);
 };
 
@@ -244,6 +255,6 @@ exports.setupEngine = (config, cache, events, log, shell, id) => {
   const LandoDaemon = require('./daemon');
   const docker = new Landerode(config.engineConfig, id);
   const daemon = new LandoDaemon(cache, events, config.dockerBin, log, config.process, config.composeBin);
-  const compose = (cmd, datum) => exports.dc(shell, config.composeBin, cmd, datum);
+  const compose = (cmd, datum) => exports.dc(shell, config.composeBin, cmd, datum, config.dockerBin, config.versions);
   return new Engine(daemon, docker, compose, config);
 };

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -129,7 +129,7 @@ exports.pull = (compose, project, opts = {}) => {
   /** @type {string[]} */
   const pull = (opts.pullable || [])
     .filter(service => !opts.services || opts.services.includes(service));
-  if (pull) {
+  if (pull.length) {
     return buildShell('pull', project, compose, {services: pull});
   }
 

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -1,14 +1,12 @@
 'use strict';
 
 // Modules
-const _ = require('lodash');
 const Cache = require('./cache');
 const env = require('./env');
 const Events = require('./events');
 const Log = require('./logger');
 const Promise = require('./promise');
 const Shell = require('./shell');
-const shell = new Shell();
 
 /*
  * Creates a new Daemon instance.
@@ -91,12 +89,22 @@ module.exports = class LandoDaemon {
    */
   getVersions() {
     return Promise.all([
-      shell.sh([`"${this.docker}"`, 'version', '--format', '{{.Server.Version}}']).catch(() => '18.0.0'),
-      shell.sh([`"${this.compose}"`, 'version', '--short']).catch(() => '11.0.0'),
+      Shell.exec([`"${this.docker}"`, 'info', '--format', 'json'], {silent: true}),
+      Shell.exec([`"${this.compose}"`, 'version', '--short'], {silent: true}),
     ])
-    .then(data => ({
-      compose: _.trim(data[1]),
-      engine: _.trim(data[0]),
-    }));
+    .then(data => {
+      let composePluginVersion = '';
+      const dockerData = JSON.parse(data[0].stdout);
+      const plugins = dockerData.ClientInfo?.Plugins;
+      if (Array.isArray(plugins)) {
+        const composePlugin = plugins.find(plugin => plugin.Name === 'compose');
+        composePluginVersion = composePlugin?.Version ?? '';
+      }
+      return {
+        engine: dockerData.ServerVersion ?? '',
+        composePlugin: composePluginVersion,
+        compose: data[1].stdout.trim(),
+      };
+    });
   };
 };

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -116,7 +116,21 @@ const bootstrapEngine = lando => {
     }
   });
 
-  return Promise.all([pluginPromise]);
+  const versionsPromise = new Promise(resolve => {
+    let versions = lando.cache.get('docker-version');
+    if (!versions) {
+      lando.engine.daemon.getVersions().then(versions => {
+        lando.config.versions = versions;
+        lando.cache.set('docker-version', versions, {ttl: 300});
+        resolve(versions);
+      });
+    } else {
+      lando.cache.set('docker-version', versions, {ttl: 300});
+      resolve(versions);
+    }
+  });
+
+  return Promise.all([pluginPromise, versionsPromise]);
 };
 
 /*

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -177,3 +177,5 @@ module.exports = class Shell {
     return _shell.which(cmd);
   };
 };
+
+module.exports.exec = exec;

--- a/test/lando.spec.js
+++ b/test/lando.spec.js
@@ -49,6 +49,7 @@ describe('lando', () => {
       // eslint-disable-next-line no-invalid-this
       this.timeout(45000);
       const lando = new Lando({logLevelConsole: 'warning'});
+      lando.cache.set('docker-version', {fake: true}, {ttl: 300});
       return lando.bootstrap().then(lando => {
         lando.config.userConfRoot.should.equal(os.tmpdir());
         lando.config.plugins.should.be.an('array').and.be.empty;
@@ -61,6 +62,7 @@ describe('lando', () => {
       process.env.JOURNEY_PRODUCT = 'steveperry';
       process.env.JOURNEY_MODE = 'rocknroll';
       const lando = new Lando({envPrefix: 'JOURNEY'});
+      lando.cache.set('docker-version', {fake: true}, {ttl: 300});
       return lando.bootstrap().then(lando => {
         lando.config.userConfRoot.should.equal(os.tmpdir());
         lando.config.plugins.should.be.an('array').and.be.empty;
@@ -80,6 +82,7 @@ describe('lando', () => {
         configSources: [path.resolve(srcRoot, 'config.yml')],
         pluginDirs: [srcRoot],
       });
+      lando.cache.set('docker-version', {fake: true}, {ttl: 300});
       return lando.bootstrap().then(lando => {
         // We need to clear out tasks because it seems to persist from require to require
         lando.tasks.tasks = [];


### PR DESCRIPTION
This PR adds support for the `compose` plugin, eliminating the need for the `docker-compose` binary.