### PR TITLE
Improve Homebrew compat - check /opt/homebrew/bin for docker and docker-compose

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -52,6 +52,7 @@ exports.getComposeExecutable = () => {
   switch (process.platform) {
     case 'darwin':
       possiblePaths.push('/Applications/Docker.app/Contents/Resources/bin');
+      possiblePaths.push('/opt/homebrew/bin');
       // fallthrough
     case 'linux':
       binary = 'docker-compose';
@@ -79,6 +80,7 @@ exports.getDockerExecutable = () => {
   switch (process.platform) {
     case 'darwin':
       possiblePaths.push('/Applications/Docker.app/Contents/Resources/bin');
+      possiblePaths.push('/opt/homebrew/bin');
       // fallthrough
     case 'linux':
       binary = 'docker';


### PR DESCRIPTION
We only check `/usr/local/bin` and `/usr/bin`, by default Homebrew installs packages in `/opt/homebrew`. This PR fixes it.