### PR TITLE
fix: exponential growth of plugin registry in `App.init()`

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,15 +19,21 @@ const initAndReport = (app, method = 'start') => {
 /*
  * Helper to load in all app plugins
  */
-const loadPlugins = (app, lando) => Promise.resolve(app.plugins.registry)
-// Filter out
-    .filter(plugin => _.has(plugin, 'app'))
-// LOADEM!
-    .map(plugin => app.plugins.load(plugin, plugin.app, app, lando))
-// Remove any naughty shit
-    .map(plugin => _.pick(plugin.data, ['config', 'composeData', 'env', 'labels']))
-// Merge minotaur
-    .each(result => _.merge(app, result));
+const loadPlugins = (app, lando) => {
+  app.appPlugins = [];
+  return Promise.resolve(app.plugins.registry)
+  // Filter out
+      .filter(plugin => _.has(plugin, 'app'))
+  // LOADEM!
+      .map(plugin => app.plugins.load(plugin, plugin.app, app, lando))
+  // Remove any naughty shit
+      .map(plugin => {
+        app.appPlugins.push(plugin);
+        return _.pick(plugin.data, ['config', 'composeData', 'env', 'labels']);
+      })
+  // Merge minotaur
+      .each(result => _.merge(app, result));
+};
 
 /**
  * The class to instantiate a new App

--- a/lib/events.js
+++ b/lib/events.js
@@ -108,6 +108,6 @@ class AsyncEvents extends EventEmitter {
 };
 
 // Set our maxListeners to something more reasonable for lando
-AsyncEvents.prototype.setMaxListeners(Infinity);
+AsyncEvents.prototype.setMaxListeners(128);
 
 module.exports = AsyncEvents;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -116,9 +116,11 @@ module.exports = class Plugins {
     }
 
     // Register, log, return
-    this.registry.push(plugin);
-    this.log.debug('plugin %s loaded from %s', plugin.name, file);
-    this.log.silly('plugin %s has', plugin.name, plugin.data);
+    if (!this.registry.find(p => p.name === plugin.name)) {
+      this.registry.push(plugin);
+      this.log.debug('plugin %s loaded from %s', plugin.name, file);
+      this.log.silly('plugin %s has', plugin.name, plugin.data);
+    }
     return plugin;
   };
 };


### PR DESCRIPTION
In Lando, `Application.init()` walks through the plugin registry (`app.plugins.registry` which is a reference to `lando.plugins.registry`) and invokes `Plugin.load()` on every plugin that has an `app.js` file.

The side effect of the `Plugin.load()` is that it adds every plugin passed to it to the registry. The net effect of this is the growth of the registry: the same plugin may be added several times.

Calls to `Lando.getApp()` and `App.init()` for a different application will double the size of the registry. Because the same plugin will be initialized twice, it will add the same event handlers twice to the application object. This eventually leads to memory leaks and the MaxListenersExceededWarning warning.

See: Automattic/vip-cli#2027