### PR TITLE
chore(deps): replace `yargonaut` with `chalk` and `figlet`

### DIFF
--- a/lib/art.js
+++ b/lib/art.js
@@ -2,9 +2,24 @@
 
 // Modules
 const _ = require('lodash');
-const niceFont = require('yargonaut').asFont;
-const chalk = require('yargonaut').chalk();
+const figlet = require('figlet');
+const chalk = require('chalk');
 const os = require('os');
+
+/**
+ * Helper to stylize text with a figlet font.
+ *
+ * @param {string} text The text to stylize.
+ * @param {figlet.Fonts} font The font to use.
+ * @return {string} The stylized text.
+ */
+const niceFont = function(text, font) {
+  try {
+    return figlet.textSync(text, {font: font});
+  } catch (err) {
+    return text;
+  }
+};
 
 /*
  * Helper to stylize code or a command

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -347,8 +347,6 @@ module.exports = class Cli {
    * Run the CLI
    */
   run(tasks = [], config = {}) {
-    const yargonaut = require('yargonaut');
-    yargonaut.style('green').errorsStyle('red');
     const yargs = require('yargs');
     const {clear, channel, secretToggle} = yargs.argv;
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -2,7 +2,7 @@
 
 // Modules
 const _ = require('lodash');
-const chalk = require('yargonaut').chalk();
+const chalk = require('chalk');
 const OldTable = require('cli-table3');
 const util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -103,9 +103,11 @@
   "dependencies": {
     "axios": "^1.8.2",
     "bluebird": "^3.4.1",
+    "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "copy-dir": "^1.3.0",
     "dockerode": "^4.0.0",
+    "figlet": "^1.8.0",
     "glob": "^7.1.3",
     "inquirer": "^6.2.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
@@ -122,7 +124,6 @@
     "uuid": "^11.0.0",
     "valid-url": "^1.0.9",
     "winston": "2.4.5",
-    "yargonaut": "^1.1.4",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,6 +1261,11 @@ figlet@^1.1.1:
   resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.8.0.tgz#1b93c4f65f4c1a3b1135221987eee8cf8b9c0ac7"
   integrity sha512-chzvGjd+Sp7KUvPHZv6EXV5Ir3Q7kYNpCr4aHrRW79qFtTefmQZNny+W1pW9kf5zeE6dikku2W50W/wAH2xWgw==
 
+figlet@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.8.1.tgz#e8e8a07e8c16be24c31086d7d5de8a9b9cf7f0fd"
+  integrity sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"


### PR DESCRIPTION
`yargonaut` is no longer maintained and has security issues (see nexdrew/yargonaut#13)

This PR replaces `yargonaut` with `chalk` and `figlet` (direct dependencies of `yargonaut`).

Because we don't need Lando CLI, we can safely eliminate `yargonaut`.
