### PR TITLE
fix: make plugin loader compatible with Jest 30

### DIFF
--- a/lib/lando.js
+++ b/lib/lando.js
@@ -79,6 +79,12 @@ const bootstrapTasks = lando => {
   // Loadem and loggem
       .then(tasks => _.flatten(tasks))
       .each(task => {
+        if (process.platform === 'win32') {
+          if (/^[\\/]{2}\?[\\/]\w:/iu.test(task)) {
+            task = task.slice(4);
+          }
+          task = task.replace(/\\/gu, path.sep);
+        }
         lando.tasks.push(require(task)(lando));
         lando.log.debug('autoloaded task %s', path.basename(task, '.js'));
       })

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -79,12 +79,6 @@ const bootstrapTasks = lando => {
   // Loadem and loggem
       .then(tasks => _.flatten(tasks))
       .each(task => {
-        if (process.platform === 'win32') {
-          if (/^[\\/]{2}\?[\\/]\w:/iu.test(task)) {
-            task = task.slice(4);
-          }
-          task = task.replace(/\\/gu, path.sep);
-        }
         lando.tasks.push(require(task)(lando));
         lando.log.debug('autoloaded task %s', path.basename(task, '.js'));
       })

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -71,7 +71,7 @@ module.exports = class Plugins {
             {}, data,
             {plugins: globSync(
                 path.join(data.dir, '*', 'index.js'),
-                process.env.NODE_ENV === 'test' ? {windowsPathsNoEscape: true, posix: true} : {},
+                process.env.NODE_ENV === 'test' ? {windowsPathsNoEscape: true} : {},
             ).sort()},
         ))
         .flatMap(data => _.map(data.plugins, plugin => buildPlugin(plugin, data.namespace)))

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -115,13 +115,6 @@ module.exports = class Plugins {
    * @return {Object} Data about our plugin.
    */
   load(plugin, file = plugin.path, ...injected) {
-    if (process.platform === 'win32') {
-      if (/^[\\/]{2}\?[\\/]\w:/iu.test(file)) {
-        file = file.slice(4);
-      }
-      file = file.replace(/\\/gu, path.sep);
-    }
-
     try {
       plugin.data = require(file)(...injected);
     } catch (e) {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -22,7 +22,7 @@ const autoLoaders = [
 ];
 
 // Helper to build out a fully fleshed plugin object
-const buildPlugin = (file, namespace)=> ({
+const buildPlugin = (file, namespace) => ({
   name: _.compact([namespace, _.last(resolver(path.dirname(file)).split(path.sep))]).join('/'),
   path: file,
   dir: path.dirname(file),
@@ -115,6 +115,13 @@ module.exports = class Plugins {
    * @return {Object} Data about our plugin.
    */
   load(plugin, file = plugin.path, ...injected) {
+    if (process.platform === 'win32') {
+      if (/^[\\/]{2}\?[\\/]\w:/iu.test(file)) {
+        file = file.slice(4);
+      }
+      file = file.replace(/\\/gu, path.sep);
+    }
+
     try {
       plugin.data = require(file)(...injected);
     } catch (e) {

--- a/test/plugins.spec.js
+++ b/test/plugins.spec.js
@@ -42,7 +42,7 @@ describe('plugins', () => {
     it('should use the plugin from the last location it finds it', () => {
       const plugins = new Plugins();
       const find = plugins.find(searchDirs);
-      expect(_.includes(find[0].path, 'cli/plugins')).to.be.true;
+      expect(_.includes(find[0].path, path.join('cli', 'plugins'))).to.be.true;
     });
 
     it('should push a plugin to the plugin registry after it is loaded', () => {


### PR DESCRIPTION
This PR makes Lando friendly to Jest 30's path resolver.

Tested in Automattic/vip-cli#2421
