### PR TITLE
fix: DEP0169

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -193,7 +193,15 @@ exports.getOclifCacheDir = (product = 'hyperdrive') => env.getOclifCacheDir(prod
  */
 exports.loadFiles = files => _(files)
 // Filter the source out if it doesn't exist
-    .filter(source => fs.existsSync(source) || fs.existsSync(source.file))
+    .filter(source => {
+      if (typeof source === 'string') {
+        return fs.existsSync(source);
+      }
+      if (typeof source.file === 'string') {
+        return fs.existsSync(source.file);
+      }
+      return false;
+    })
 // If the file is just a string lets map it to an object
     .map(source => {
       return _.isString(source) ? {file: source, data: yaml.load(fs.readFileSync(source)) || {}} : source;

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -19,14 +19,14 @@ const DEFAULT_VERSIONS = {networking: 1};
 
 // Helper to get init config
 const getInitConfig = dirs => _(dirs)
-    .filter(dir => fs.existsSync(dir))
+    .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
     .flatMap(dir => globSync(path.join(dir, '*', 'init.js')).sort())
     .map(file => require(file))
     .value();
 
 // Helper to get init source config
 const getInitSourceConfig = dirs => _(dirs)
-    .filter(dir => fs.existsSync(dir))
+    .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
     .flatMap(dir => globSync(path.join(dir, '*.js')).sort())
     .map(file => require(file))
     .flatMap(source => source.sources)
@@ -69,7 +69,7 @@ const bootstrapTasks = lando => {
   // Load in all our tasks
   return lando.Promise.resolve(lando.config.plugins)
   // Make sure the tasks dir exists
-      .filter(plugin => fs.existsSync(plugin.tasks))
+      .filter(plugin => typeof plugin.tasks === 'string' && fs.existsSync(plugin.tasks))
   // Get a list off full js files that exist in that dir
       .map(plugin => _(fs.readdirSync(plugin.tasks))
           .map(file => path.join(plugin.tasks, file))
@@ -108,7 +108,7 @@ const bootstrapEngine = lando => {
 
   // Auto move and make executable any scripts
   const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {
-    if (fs.existsSync(plugin.scripts)) {
+    if (typeof plugin.scripts === 'string' && fs.existsSync(plugin.scripts)) {
       const confDir = path.join(lando.config.userConfRoot, 'scripts');
       const dest = lando.utils.moveConfig(plugin.scripts, confDir);
       lando.utils.makeExecutable(fs.readdirSync(dest), dest);
@@ -144,7 +144,7 @@ const bootstrapApp = lando => {
   // Load in all our builders in the correct order
   const builders = _(['compose', 'types', 'services', 'recipes'])
       .flatMap(type => _.map(lando.config.plugins, plugin => plugin[type]))
-      .filter(dir => fs.existsSync(dir))
+      .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
       .flatMap(dir => globSync(path.join(dir, '*', 'builder.js')).sort())
       .map(file => lando.factory.add(require(file)).name)
       .value();


### PR DESCRIPTION
This PR fixes the `Passing invalid argument types to fs.existsSync is deprecated` warning.