### PR TITLE
fix: increase request timeout to 15s

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -45,7 +45,7 @@ module.exports = (log = new Log()) => {
    * @param {Object} [opts] Options to configure the scan.
    * @param {number} [opts.max=7] The amount of times to retry accessing each URL.
    * @param {number[]} [opts.waitCodes=[400, 502, 404]] The HTTP codes to prompt a retry.
-   * @param {number} [opts.timeout=5000] The timeout for each request in milliseconds.
+   * @param {number} [opts.timeout=15000] The timeout for each request in milliseconds.
    * @return {Array} An array of objects of the form {url: url, status: true|false}
    * @example
    * // Scan URLs and print results
@@ -54,7 +54,7 @@ module.exports = (log = new Log()) => {
    *   console.log(results);
    * });
    */
-  const scanUrls = (urls, {max = 7, waitCodes = [400, 502, 404], timeout = 5000} = {}) => {
+  const scanUrls = (urls, {max = 7, waitCodes = [400, 502, 404], timeout = 15000} = {}) => {
     log.verbose('about to scan urls');
     log.debug('scanning data', {urls, max, waitCodes});
 


### PR DESCRIPTION
This pull request makes a small but significant change to the `lib/scan.js` file by increasing the timeout duration for HTTP requests during URL scans. The timeout has been updated from 5000 milliseconds (5 seconds) to 15000 milliseconds (15 seconds) to allow more time for slower requests to complete.

* **Timeout adjustment for URL scans**:
  * Increased the default `timeout` value in the function documentation from 5000ms to 15000ms.
  * Updated the default `timeout` value in the `scanUrls` function definition to match the new 15000ms value.