### PR TITLE
fix: `glob` usage for Windows

### DIFF
--- a/lib/lando.js
+++ b/lib/lando.js
@@ -5,6 +5,7 @@ const bootstrap = require('./bootstrap');
 const fs = require('fs');
 const {globSync} = require('glob');
 const path = require('path');
+const {normalizePathForGlob} = require('./utils');
 
 // Bootstrap levels
 const BOOTSTRAP_LEVELS = {
@@ -20,14 +21,14 @@ const DEFAULT_VERSIONS = {networking: 1};
 // Helper to get init config
 const getInitConfig = dirs => _(dirs)
     .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
-    .flatMap(dir => globSync(path.join(dir, '*', 'init.js')).sort())
+    .flatMap(dir => globSync(normalizePathForGlob(path.join(dir, '*', 'init.js'))).sort())
     .map(file => require(file))
     .value();
 
 // Helper to get init source config
 const getInitSourceConfig = dirs => _(dirs)
     .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
-    .flatMap(dir => globSync(path.join(dir, '*.js')).sort())
+    .flatMap(dir => globSync(normalizePathForGlob(path.join(dir, '*.js'))).sort())
     .map(file => require(file))
     .flatMap(source => source.sources)
     .value();
@@ -145,7 +146,7 @@ const bootstrapApp = lando => {
   const builders = _(['compose', 'types', 'services', 'recipes'])
       .flatMap(type => _.map(lando.config.plugins, plugin => plugin[type]))
       .filter(dir => typeof dir === 'string' && fs.existsSync(dir))
-      .flatMap(dir => globSync(path.join(dir, '*', 'builder.js')).sort())
+      .flatMap(dir => globSync(normalizePathForGlob(path.join(dir, '*', 'builder.js'))).sort())
       .map(file => lando.factory.add(require(file)).name)
       .value();
   // Log

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const {globSync} = require('glob');
 const Log = require('./logger');
 const path = require('path');
+const {normalizePathForGlob} = require('./utils');
 const resolver = (process.platform === 'win32') ? path.win32.resolve : path.posix.resolve;
 
 // List of autoload locations to scan for
@@ -70,8 +71,7 @@ module.exports = class Plugins {
         .flatMap(data => _.merge(
             {}, data,
             {plugins: globSync(
-                path.join(data.dir, '*', 'index.js'),
-                process.env.NODE_ENV === 'test' ? {windowsPathsNoEscape: true} : {},
+                normalizePathForGlob(path.join(data.dir, '*', 'index.js')),
             ).sort()},
         ))
         .flatMap(data => _.map(data.plugins, plugin => buildPlugin(plugin, data.namespace)))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,3 +218,12 @@ exports.validateFiles = (files = [], base = process.cwd()) => _(files)
     .map(file => (path.isAbsolute(file) ? file : path.join(base, file)))
     .filter(file => fs.existsSync(file))
     .value();
+
+/**
+ * Normalizes a path for use with the `glob` package.
+ * On Windows, it replaces backslashes with forward slashes.
+ * On other platforms, it returns the path unchanged.
+ * @param {string} p - The path to normalize.
+ * @return {string} - The normalized path.
+ */
+exports.normalizePathForGlob = p => os.platform() === 'win32' ? p.replace(/\\/g, '/') : p;


### PR DESCRIPTION
This pull request introduces a utility function, `normalizePathForGlob`, to ensure consistent path formatting for the `glob` package, particularly addressing platform-specific path differences. The function is integrated across multiple modules to improve compatibility and maintainability.

### New Utility Function:
* [`lib/utils.js`](diffhunk://#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780aR221-R229): Added `normalizePathForGlob`, which ensures paths are formatted with forward slashes on Windows and left unchanged on other platforms. This improves compatibility with the `glob` package.

### Integration of `normalizePathForGlob`:
* `lib/lando.js`:
  - Updated all instances of `globSync` to use `normalizePathForGlob` for paths in `getInitConfig`, `getInitSourceConfig`, and `bootstrapApp` functions. [[1]](diffhunk://#diff-3b5eaf141d60a6350440399209dc8bd2ce83101f3416b56a1cdc165f39e6f2a0L23-R31) [[2]](diffhunk://#diff-3b5eaf141d60a6350440399209dc8bd2ce83101f3416b56a1cdc165f39e6f2a0L148-R149)
  - Imported `normalizePathForGlob` from `./utils`.
* `lib/plugins.js`:
  - Replaced direct path usage with `normalizePathForGlob` in the `Plugins` class to ensure consistent path handling for plugin discovery.
  - Imported `normalizePathForGlob` from `./utils`.