### PR TITLE
fix(util): update base image for `devwithlando/util`

### DIFF
--- a/plugins/lando-core/types/utility/Dockerfile
+++ b/plugins/lando-core/types/utility/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t devwithlando/util:4 .
 
-FROM debian:buster-slim
-RUN apt-get update && apt-get install -y \
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
     bzip2 \
     curl \
     git-core \


### PR DESCRIPTION
This pull request updates the base image for the utility Dockerfile to use a newer Debian release and improves package installation practices.

Dockerfile base image and installation improvements:

* Updated the base image in `plugins/lando-core/types/utility/Dockerfile` from `debian:buster-slim` to `debian:bookworm-slim` for improved security and up-to-date packages.
* Modified the package installation command to use `--no-install-recommends`, reducing the image size by avoiding unnecessary recommended packages.