### PR TITLE
fix: rename `devwithlando/util` to `ghcr.io/automattic/vip-container-images/lando-util`

### DIFF
--- a/.github/workflows/build-util-images.yml
+++ b/.github/workflows/build-util-images.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: util
+          - image: lando-util
             tag: 4
             context: plugins/lando-core/types/utility
 
@@ -35,15 +35,16 @@ jobs:
         id: pr
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "::set-output name=TAG_SUFFIX::-edge"
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: https://ghcr.io
+      - name: Build and push ghcr.io/automattic/vip-container-images/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           platforms: linux/amd64,linux/arm64
-          push: false
-          tags: devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}
+          push: true
+          tags: ghcr.io/automattic/vip-container-images/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.TAG_SUFFIX }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building utility Docker images. The main changes involve switching to using GitHub Container Registry (GHCR) instead of Docker Hub, and renaming the image from `util` to `lando-util`.

**Container image and registry updates:**

* Changed the image name in the build matrix from `util` to `lando-util` to better reflect its purpose.
* Updated the workflow to authenticate with GHCR using GitHub credentials, and changed the image repository from DockerHub to `ghcr.io/automattic/vip-container-images`. The workflow now pushes images to GHCR instead of DockerHub.
* Enabled pushing built images by setting `push: true` (previously `push: false`) in the Docker build step.