### PR TITLE
fix(util): add `openssl` package

### DIFF
--- a/plugins/lando-core/types/utility/Dockerfile
+++ b/plugins/lando-core/types/utility/Dockerfile
@@ -1,16 +1,9 @@
 # docker build -t devwithlando/util:4 .
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bzip2 \
-    curl \
-    git-core \
-    jq \
-    rsync \
-    ssh \
-    wget \
-    unzip \
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends bzip2 curl git-core jq openssl rsync ssh wget unzip \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+  && rm -rf /var/lib/apt/lists/* /var/lib/cache/* /var/lib/log/* /tmp/*

--- a/plugins/lando-core/types/utility/Dockerfile
+++ b/plugins/lando-core/types/utility/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && \
   && apt-get -y clean \
   && apt-get -y autoclean \
   && apt-get -y autoremove \
-  && rm -rf /var/lib/apt/lists/* /var/lib/cache/* /var/lib/log/* /tmp/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/*


### PR DESCRIPTION
This pull request makes a minor update to the `plugins/lando-core/types/utility/Dockerfile` to optimize the Docker image and add a missing dependency.

- Added `openssl` to the list of installed packages to ensure it's available in the utility image.
- Simplified the cleanup command by combining multiple `rm -rf` commands into a single line for efficiency.