### PR TITLE
refactor: replace `uuid` with `node:crypto`

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // Modules
+const {randomUUID} = require('crypto');
 const _ = require('lodash');
 const merger = require('./config').merge;
 const fs = require('fs');
@@ -237,10 +238,9 @@ exports.getTasks = (config = {}, argv = {}, tasks = []) => {
  * Helper to setup cache
  */
 exports.setupCache = (log, config) => {
-  const {v4: random} = require('uuid');
   const Cache = require('./cache');
   const cache = new Cache({log, cacheDir: path.join(config.userConfRoot, 'cache')});
-  if (!cache.get('id')) cache.set('id', random(), {persist: true});
+  if (!cache.get('id')) cache.set('id', randomUUID(), {persist: true});
   config.user = cache.get('id');
   config.id = config.user;
   return cache;

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "string-argv": "0.1.1",
     "through": "^2.3.8",
     "transliteration": "^2.3.5",
-    "uuid": "^11.0.0",
     "valid-url": "^1.0.9",
     "winston": "^3.11.0",
     "yargs": "^16.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,11 +3525,6 @@ uuid@^10.0.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
-uuid@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"


### PR DESCRIPTION
This pull request updates the way unique IDs are generated for caching by switching from the `uuid` package to Node.js's built-in `crypto.randomUUID` method. This reduces external dependencies and simplifies the codebase.

Dependency management:

* Removed the `uuid` package from `package.json` as it is no longer needed due to using the built-in `crypto` module.

Code updates for ID generation:

* Updated `lib/bootstrap.js` to import `randomUUID` from Node.js's `crypto` module instead of requiring `uuid`.
* Changed the cache ID generation in `setupCache` to use `randomUUID()` instead of `uuid.v4()`.