### PR TITLE
fix: do not lose original error when re-throwing

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -23,7 +23,7 @@ const loadCacheFile = file => {
   try {
     return JSON.parse(JSON.parse(fs.readFileSync(file, {encoding: 'utf-8'})));
   } catch (e) {
-    throw new Error(`There was a problem with parsing ${file}. Ensure it is valid JSON! ${e}`);
+    throw new Error(`There was a problem with parsing ${file}. Ensure it is valid JSON! ${e}`, {cause: e});
   }
 };
 
@@ -34,7 +34,7 @@ const loadLandoFile = file => {
   try {
     return yaml.load(fs.readFileSync(file));
   } catch (e) {
-    throw new Error(`There was a problem with parsing ${file}. Ensure it is valid YAML! ${e}`);
+    throw new Error(`There was a problem with parsing ${file}. Ensure it is valid YAML! ${e}`, {cause: e});
   }
 };
 
@@ -140,14 +140,16 @@ exports.buildConfig = options => {
  * Helper for docker compose
  * @TODO: eventually this needs to live somewhere else so we can have a better
  * default engine instantiation
- *
  * @param {Shell} shell
  * @param {string} bin
  * @param {string} cmd
- * @param {Object} datum
+ * @param {object} datum
+ * @param datum.opts
+ * @param datum.project
+ * @param datum.compose
  * @param {string} dockerBin
- * @param {Object} versions
- * @return {Promise<string>}
+ * @param {object} versions
+ * @returns {Promise<string>}
  */
 exports.dc = (shell, bin, cmd, {compose, project, opts = {}}, dockerBin, versions) => {
   const dockerCompose = require('./compose');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -142,7 +142,7 @@ exports.moveConfig = (src, dest = os.tmpdir()) => {
 
     // Catch this so we can try to repair
     if (code !== 'EISDIR' || syscall !== 'open' || !!fs.mkdirSync(f, {recursive: true})) {
-      throw new Error(error);
+      throw error;
     }
 
     // Try to take corrective action
@@ -224,6 +224,6 @@ exports.validateFiles = (files = [], base = process.cwd()) => _(files)
  * On Windows, it replaces backslashes with forward slashes.
  * On other platforms, it returns the path unchanged.
  * @param {string} p - The path to normalize.
- * @return {string} - The normalized path.
+ * @returns {string} - The normalized path.
  */
 exports.normalizePathForGlob = p => os.platform() === 'win32' ? p.replace(/\\/g, '/') : p;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "sinon-chai": "^3.7.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "debug": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/lando/cli/issues"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "main": "lib/lando.js",
   "bin": {

--- a/test/scan.spec.js
+++ b/test/scan.spec.js
@@ -22,7 +22,7 @@ describe('scan', () => {
         get: url => {
           counter[url] = counter[url] + 1 || 0;
           const last = _.last(url.split('.'));
-          let code = 200;
+          let code;
           if (_.includes(last, ':')) {
             if (_.toInteger(last.split(':')[1]) === counter[url]) code = 200;
             else code = last.split(':')[0];


### PR DESCRIPTION
This pull request introduces several improvements to error handling and documentation in the `lib/bootstrap.js` and `lib/utils.js` files. The main focus is on enhancing error propagation by including the original error as the cause, refining documentation for better clarity, and making minor consistency improvements.

**Error handling improvements:**

* Updated error throwing in `loadCacheFile` and `loadLandoFile` to include the original error as the `cause` property, which improves error traceability and debugging. [[1]](diffhunk://#diff-ea4bc12766cafba11bfcdb79e5abed42c9f9a633c47d92943832ad77d9966e4aL26-R26) [[2]](diffhunk://#diff-ea4bc12766cafba11bfcdb79e5abed42c9f9a633c47d92943832ad77d9966e4aL37-R37)
* Changed error propagation in `moveConfig` to rethrow the original error instead of wrapping it in a new `Error` object, preserving the original error information.

**Documentation and consistency:**

* Improved JSDoc comments in `buildConfig` and related functions by clarifying parameter types, adding missing parameter descriptions, and standardizing the use of `@returns` over `@return`. [[1]](diffhunk://#diff-ea4bc12766cafba11bfcdb79e5abed42c9f9a633c47d92943832ad77d9966e4aL143-R152) [[2]](diffhunk://#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780aL227-R227)