### PR TITLE
refactor: dead code elimination

### DIFF
--- a/bin/lando.js
+++ b/bin/lando.js
@@ -41,9 +41,6 @@ process.landoTaskCacheName = '_.tasks.cache';
 process.landoTaskCacheFile = path.join(cli.defaultConfig().userConfRoot, 'cache', process.landoTaskCacheName);
 process.landoAppTaskCacheFile = !_.isEmpty(config) ? config.toolingCache : undefined;
 
-// Check for sudo usage
-cli.checkPerms();
-
 // Check to see if we have a recipe and if it doesn't have a tooling cache lets enforce a manual cache clear
 if (bsLevel === 'APP' && !fs.existsSync(config.toolingCache)) {
   if (fs.existsSync(process.landoTaskCacheFile)) fs.unlinkSync(process.landoTaskCacheFile);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,18 +68,6 @@ module.exports = class Cli {
   }
 
   /**
-   * Checks to see if lando is running with sudo. If it is it
-   * will exit the process with a stern warning
-   * @since 3.0.0
-   * @alias lando.cli.checkPerms
-   * @example
-   * lando.cli.checkPerms()
-   */
-  checkPerms() {
-    /* Do nothing */
-  }
-
-  /**
    * Clears cached task metadata files.
    * @returns {void}
    */
@@ -324,9 +312,8 @@ module.exports = class Cli {
             .then(() => lando.events.emit('cli-answers', data, argv._[0]))
             .then(() => lando.events.emit(`cli-${argv._[0]}-answers`, data, argv._[0]))
 
-        // Attempt to filter out questions that have already been answered
-        // Prompt the use for feedback if needed and sort by weight
-            .then(() => formatters.handleInteractive(data.inquiry, data.options, command, lando))
+        // Interactive prompting is not implemented here, so continue with empty answers.
+            .then(() => ({}))
 
         /**
          * Event that allows final altering of answers before the task runs

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -78,20 +78,14 @@ module.exports = class Cli {
 
   /**
    * Builds a reusable confirmation option definition.
-   * @param {string} [message] Prompt message.
-   * @returns {object} Interactive option definition.
+   * @returns {object} CLI option definition.
    */
-  confirm(message = 'Are you sure?') {
+  confirm() {
     return {
       describe: 'Auto answer yes to prompts',
       alias: ['y'],
       default: false,
       boolean: true,
-      interactive: {
-        type: 'confirm',
-        default: false,
-        message: message,
-      },
     };
   }
 
@@ -269,8 +263,7 @@ module.exports = class Cli {
    */
   parseToYargs({command, describe, options = {}, run = {}, level = 'app'}, config = {}) {
     const handler = argv => {
-      // Immediately build some arg data set opts and interactive options
-      const data = {options: argv, inquiry: formatters.getInteractive(options, argv)};
+      const data = {options: argv};
 
       // Summon lando
       const Lando = require('./../lib/lando');
@@ -300,19 +293,6 @@ module.exports = class Cli {
             }
           }
         })
-        /**
-         * Event that allows altering of argv or inquirer before interactive prompts
-         * are run
-         *
-         * You will want to replace CMD with the actual task name eg `task-start-answers`.
-         * @since 3.0.0
-         * @event task_CMD_answers
-         * @property {object} answers argv and inquirer questions
-         */
-            .then(() => lando.events.emit('cli-answers', data, argv._[0]))
-            .then(() => lando.events.emit(`cli-${argv._[0]}-answers`, data, argv._[0]))
-
-        // Interactive prompting is not implemented here, so continue with empty answers.
             .then(() => ({}))
 
         /**

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -36,9 +36,6 @@ module.exports = class Engine {
     this.composeInstalled = config.composeBin !== false;
     /** @type {boolean} */
     this.dockerInstalled = this.daemon.docker !== false;
-    // Grab the supported ranges for our things
-    /** @type {object} */
-    this.supportedVersions = config.dockerSupportedVersions;
   };
 
   /**

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -79,27 +79,6 @@ exports.formatData = (data, {path = '', format = 'default', filter = []} = {}, o
 exports.formatOptions = (omit = []) => _.omit(formatOpts, omit);
 
 /**
- * Extracts interactive option definitions in prompt order.
- * @param {object} options Command option definitions.
- * @param {object} argv Parsed argv values.
- * @returns {object[]} Interactive option metadata.
- */
-exports.getInteractive = (options, argv) => _(options)
-    .map((option, name) => _.merge({}, {name}, {option}))
-    .filter(option => !_.isEmpty(_.get(option, 'option.interactive', {})))
-    .map(option => _.merge({}, {name: option.name, weight: 0}, option.option.interactive))
-    .map(option => {
-      if (_.isNil(argv[option.name]) || argv[option.name] === false) return option;
-      else {
-        return _.merge({}, option, {when: answers => {
-          answers[option.name] = argv[option.name];
-          return false;
-        }});
-      }
-    })
-    .value();
-
-/**
  * Sorts option objects by key name.
  * @param {object} options Option config keyed by name.
  * @returns {object} Sorted option config.

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -100,18 +100,6 @@ exports.getInteractive = (options, argv) => _(options)
     .value();
 
 /**
- * Placeholder for interactive prompting flow.
- * @param {object[]} inquiry Prompt definitions.
- * @param {object} argv Parsed argv values.
- * @param {string} command Command name.
- * @param {object} lando Lando runtime instance.
- * @returns {Promise<object>} Prompt answers.
- */
-exports.handleInteractive = (inquiry, argv, command, lando) => lando.Promise.try(() => {
-  return {};
-});
-
-/**
  * Sorts option objects by key name.
  * @param {object} options Option config keyed by name.
  * @returns {object} Sorted option config.

--- a/plugins/lando-core/tasks/destroy.js
+++ b/plugins/lando-core/tasks/destroy.js
@@ -5,7 +5,7 @@ module.exports = lando => {
     command: 'destroy',
     describe: 'Destroys your app',
     options: {
-      yes: lando.cli.confirm('Are you sure you want to DESTROY?'),
+      yes: lando.cli.confirm(),
     },
     run: options => {
       // Stop rebuild if user decides its a nogo

--- a/plugins/lando-core/tasks/rebuild.js
+++ b/plugins/lando-core/tasks/rebuild.js
@@ -13,7 +13,7 @@ module.exports = lando => {
         alias: ['s'],
         array: true,
       },
-      yes: lando.cli.confirm('Are you sure you want to rebuild?'),
+      yes: lando.cli.confirm(),
     },
     run: options => {
       if (!options.yes) {

--- a/plugins/lando-recipes/lib/options.js
+++ b/plugins/lando-recipes/lib/options.js
@@ -16,13 +16,6 @@ const coreOpts = sources => ({
     choices: _.map(sources, 'name'),
     alias: ['src'],
     string: true,
-    interactive: {
-      type: 'list',
-      message: 'From where should we get your app\'s codebase?',
-      default: 'cwd',
-      choices: _.map(sources, source => ({name: source.label, value: source.name})),
-      weight: 100,
-    },
   },
 });
 
@@ -64,15 +57,6 @@ const getConflicts = (name, all, lando) => _(all)
 const nameOpts = {
   describe: 'The name of the app',
   string: true,
-  interactive: {
-    type: 'input',
-    message: () => 'What do you want to call this app?',
-    default: () => 'My Lando App',
-    filter: input => utils.appMachineName(input),
-    when: () => true,
-    weight: 1000,
-    validate: () => true,
-  },
 };
 
 /**
@@ -85,31 +69,12 @@ const recipeOpts = recipes => ({
   choices: recipes,
   alias: ['r'],
   string: true,
-  interactive: {
-    type: 'list',
-    message: () => 'What recipe do you want to use?',
-    default: () => 'lamp',
-    choices: _.map(recipes, recipe => ({name: recipe, value: recipe})),
-    filter: input => input,
-    when: () => true,
-    weight: 500,
-    validate: () => true,
-  },
 });
 
 /** @type {object} */
 const webrootOpts = {
   describe: 'Specify the webroot relative to app root',
   string: true,
-  interactive: {
-    type: 'input',
-    message: () => 'Where is your webroot relative to the init destination?',
-    default: () => '.',
-    filter: input => input,
-    when: answers => true,
-    weight: 900,
-    validate: () => true,
-  },
 };
 
 /**
@@ -178,30 +143,3 @@ exports.parseOptions = options => {
   return options;
 };
 
-/**
- * Applies dynamic overrides to auxiliary init options.
- * @param {object[]} [inits] Init plugin configs.
- * @param {string[]} [recipes] Available recipe names.
- * @param {object[]} [sources] Available source definitions.
- * @returns {object} Overridden auxiliary option config.
- */
-exports.overrideOpts = (inits = [], recipes = [], sources = []) => {
-  const opts = auxOpts(recipes);
-  _.forEach(opts, (opt, key) => {
-    const isRec = key === 'recipe';
-    // NOTE: when seems like the most relevant override here, should we consider adding more?
-    // are we restricted by access to the answers hash or when these things actually run?
-    _.forEach(['when'], prop => {
-      const overrideFunc = answers => {
-        const config = isRec ? exports.getConfig(sources, answers.source) : exports.getConfig(inits, answers.recipe);
-        if (_.has(config, `overrides.${key}.${prop}`) && _.isFunction(config.overrides[key][prop])) {
-          return config.overrides[key][prop](answers);
-        } else {
-          return opt.interactive[prop](answers);
-        }
-      };
-      opts[key] = _.merge({}, {interactive: _.set({}, prop, overrideFunc)});
-    });
-  });
-  return opts;
-};

--- a/plugins/lando-recipes/sources/remote.js
+++ b/plugins/lando-recipes/sources/remote.js
@@ -1,21 +1,5 @@
 'use strict';
 
-/**
- * Validates that a given input is a valid URI.
- *
- * @param {string} input The input string to validate.
- * @return {boolean} True if the input is a valid URI, false otherwise.
- */
-function isValidUri(input) {
-  try {
-    const url = new URL(input);
-    return (url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'git:') &&
-      url.hostname.length > 0;
-  } catch {
-    return false;
-  }
-}
-
 module.exports = {
   sources: [{
     name: 'remote',
@@ -24,16 +8,6 @@ module.exports = {
       'remote-url': {
         describe: 'The URL of your git repo or archive, only works when you set source to remote',
         string: true,
-        interactive: {
-          type: 'input',
-          message: 'Please enter the URL of the git repo or tar archive containing your application code',
-          when: answers => answers.source === 'remote',
-          validate: input => {
-            if (isValidUri(input)) return true;
-            return `${input} does not seem to be a valid uri!`;
-          },
-          weight: 110,
-        },
       },
       'remote-options': {
         default: '',

--- a/plugins/lando-recipes/tasks/init.js
+++ b/plugins/lando-recipes/tasks/init.js
@@ -53,7 +53,7 @@ module.exports = lando => {
     command: 'init',
     level: 'app',
     describe: 'Initializes code for use with lando',
-    options: _.merge(opts.baseOpts(recipes, sources), configOpts, opts.overrideOpts(inits, recipes, sources)),
+    options: _.merge(opts.baseOpts(recipes, sources), configOpts),
     run: options => {
       // Parse options abd and configs
       options = opts.parseOptions(options);

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -28,21 +28,10 @@ const fakeTask = {
       alias: ['y'],
       default: false,
       boolean: true,
-      interactive: {
-        type: 'confirm',
-        default: false,
-        message: 'Are you ok?',
-      },
     },
     other: {
       describe: 'some other thing',
       string: true,
-      interactive: {
-        type: 'input',
-        message: 'what is it?',
-        default: 'nothing',
-        weight: 4,
-      },
     },
   },
   run: options => options,

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -78,13 +78,6 @@ describe('cli', () => {
     });
   });
 
-  describe('#checkPerms', () => {
-    it('should be the same as sudoBlock', () => {
-      const cli = new Cli();
-      cli.checkPerms();
-    });
-  });
-
   describe('#defaultConfig', () => {
     it('should return default config object that can be used to bootstrap a lando cli', () => {
       const cli = new Cli();


### PR DESCRIPTION
This pull request removes support for interactive CLI prompts and related metadata from the codebase, simplifying command and option handling to non-interactive (flag-based) usage. It eliminates the `interactive` option definitions, associated prompt logic, and dynamic overrides, resulting in a more straightforward and maintainable CLI. Several unused or redundant methods and tests are also removed.

**Removal of interactive prompt support:**

* All `interactive` metadata (such as prompt messages, types, and validation logic) has been removed from CLI option definitions in files like `plugins/lando-recipes/lib/options.js`, `plugins/lando-recipes/sources/remote.js`, and related test files. [[1]](diffhunk://#diff-a36347b893384917cef95afee4a033dab7ebc3223809c028a1b0f952811e31ccL19-L25) [[2]](diffhunk://#diff-a36347b893384917cef95afee4a033dab7ebc3223809c028a1b0f952811e31ccL67-L75) [[3]](diffhunk://#diff-a36347b893384917cef95afee4a033dab7ebc3223809c028a1b0f952811e31ccL88-L112) [[4]](diffhunk://#diff-ea437762e9f99856a495693448bb47c516ad177ab4631ac4293eb06ff54cda2bL27-L36) [[5]](diffhunk://#diff-f2c1d6ba42df5bead9c1032e40bd6133e8ce9e67499b461eb6ee3ef328c5d59cL31-L45)
* The `getInteractive` and `handleInteractive` functions, which extracted and processed interactive option definitions for prompts, have been deleted from `lib/formatters.js`.
* All logic for building and handling prompt flows during CLI command execution has been removed from `lib/cli.js`, including the removal of related event emissions and the simplification of the `parseToYargs` method. [[1]](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4L284-R266) [[2]](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4L315-R296)

**Simplification and cleanup of CLI option definitions and methods:**

* The `confirm` method in `lib/cli.js` no longer accepts a custom message or returns interactive prompt metadata; it now only defines a simple boolean CLI flag. [[1]](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4L93-L106) [[2]](diffhunk://#diff-871523224427bcc3bc30a86472a359a67896f205670cd4c89bbe0faa399134f5L8-R8) [[3]](diffhunk://#diff-497c031934196cfab44c78ac40dabd3e4a79467237a8b9bdc4f8f8c5e4e95214L16-R16)
* The `overrideOpts` function, which dynamically applied overrides to interactive options, has been removed from `plugins/lando-recipes/lib/options.js`, and its usage has been eliminated from `plugins/lando-recipes/tasks/init.js`. [[1]](diffhunk://#diff-a36347b893384917cef95afee4a033dab7ebc3223809c028a1b0f952811e31ccL181-L207) [[2]](diffhunk://#diff-de42fef5f89824c2cf8830826d4ceb82bcec7e38a41d5b6538377a056db39c60L56-R56)

**Removal of unused or redundant code:**

* The `checkPerms` method and its associated test have been removed from `lib/cli.js` and `test/cli.spec.js`, respectively. [[1]](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4L70-L81) [[2]](diffhunk://#diff-f2c1d6ba42df5bead9c1032e40bd6133e8ce9e67499b461eb6ee3ef328c5d59cL81-L87)
* The unused `isValidUri` function has been deleted from `plugins/lando-recipes/sources/remote.js`.
* The unused `supportedVersions` property has been removed from the `Engine` class in `lib/engine.js`.