### PR TITLE
Update Django example dependency

### DIFF
--- a/examples/django/.lando.yml
+++ b/examples/django/.lando.yml
@@ -1,7 +1,7 @@
 name: lando-django
 services:
   appserver:
-    type: python
+    type: python:3.11
     build:
       - pip install -r requirements.txt
 tooling:

--- a/examples/django/README.md
+++ b/examples/django/README.md
@@ -25,7 +25,7 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should be able to run django-admin without errors
-lando django-admin --version | grep "^2."
+lando django-admin --version | grep "^4."
 ```
 
 Destroy tests

--- a/examples/django/requirements.txt
+++ b/examples/django/requirements.txt
@@ -1,4 +1,4 @@
 # requirements.txt
 
-Django>=2.0,<3.0
+Django>=4.2.26,<5.0
 psycopg2>=2.7,<3.0


### PR DESCRIPTION
## Summary
- Update the Django example requirement from the vulnerable 2.x range to the patched 4.2 LTS range.
- Update the example verification command to expect Django 4.x.

## Testing
- `git diff --check`
- `python3 -m pip index versions Django`
- `python3 -m pip install --dry-run 'Django>=4.2.26,<5.0'`\n\n## Notes\n- Full example requirements dry-run reached Django 4.2.30, then failed while building the existing `psycopg2` dependency because `pg_config` is not installed locally.